### PR TITLE
fix: vscode-remote support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@
 name: CI
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,15 +27,15 @@ jobs:
             rust-target: aarch64-pc-windows-msvc
             platform: win32
             arch: arm64
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             rust-target: x86_64-unknown-linux-gnu
             platform: linux
             arch: x64
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             rust-target: aarch64-unknown-linux-gnu
             platform: linux
             arch: arm64
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             rust-target: arm-unknown-linux-gnueabihf
             platform: linux
             arch: armhf

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -310,6 +310,7 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 				.toString()}/typst-webview-assets`
 		);
 		panel.webview.html = html.replace("ws://127.0.0.1:23625", `ws://127.0.0.1:${dataPlanePort}`);
+		await vscode.env.asExternalUri(vscode.Uri.parse(`http://127.0.0.1:${dataPlanePort}`));
 		activeTask.set(bindDocument, {
 			panel,
 			addonΠserver,

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -310,7 +310,7 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 				.toString()}/typst-webview-assets`
 		);
 		panel.webview.html = html.replace("ws://127.0.0.1:23625", `ws://127.0.0.1:${dataPlanePort}`);
-		await vscode.env.asExternalUri(vscode.Uri.parse(`http://127.0.0.1:${dataPlanePort}`));
+		await vscode.env.asExternalUri(vscode.Uri.parse(`ws://127.0.0.1:${dataPlanePort}`));
 		activeTask.set(bindDocument, {
 			panel,
 			addonΠserver,

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -57,8 +57,9 @@ export async function getCliPath(extensionPath?: string): Promise<string> {
 		}
 
 		vscode.window.showWarningMessage(
-			`Failed to find ${state.BINARY_NAME} executable at ${bundledPath},` +
-			`maybe we didn't ship it for your platform? Using ${state.BINARY_NAME} from PATH`);
+			`${state.BINARY_NAME} executable at ${bundledPath} not working,` +
+			`maybe we didn't ship it for your platform or it cannot run due to library issues?` +
+			`In this case you need compile and add ${state.BINARY_NAME} to your PATH.`);
 		return state.BINARY_NAME;
 	};
 

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -311,7 +311,9 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 				.toString()}/typst-webview-assets`
 		);
 		panel.webview.html = html.replace("ws://127.0.0.1:23625", `ws://127.0.0.1:${dataPlanePort}`);
-		await vscode.env.asExternalUri(vscode.Uri.parse(`ws://127.0.0.1:${dataPlanePort}`));
+		// 虽然配置的是 http，但是如果是桌面客户端，任何 tcp 连接都支持，这也就包括了 ws
+		// https://code.visualstudio.com/api/advanced-topics/remote-extensions#forwarding-localhost
+		await vscode.env.asExternalUri(vscode.Uri.parse(`http://127.0.0.1:${dataPlanePort}`));
 		activeTask.set(bindDocument, {
 			panel,
 			addonΠserver,


### PR DESCRIPTION
fix #41 
[related doc](https://code.visualstudio.com/api/advanced-topics/remote-extensions#forwarding-localhost)

> Note: Currently the forwarding mechanism in the Codespaces browser-based editor **only supports http and https requests**. However, **you can interact with any TCP connection** when connecting to a codespace from VS Code.

Since ws is based on TCP, it works.

But I didn't test whether Codespaces browser-based editor supports ws or not.