### PR TITLE
bump version to 0.7.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typst-preview"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["The Typst Project Developers"]
 edition = "2021"
 

--- a/addons/vscode/CHANGELOG.md
+++ b/addons/vscode/CHANGELOG.md
@@ -115,3 +115,11 @@ Add preview button
   - fix #41. It is now possible to use Typst Preview in VSCode Remote.
   - fix #82. You can have preview button even when typst-lsp is not installed.
 - Misc: We downgrade the ci image for Linux to Ubuntu 20.04. This should fix the problem where the extension cannot be installed on some old Linux distros.
+
+## v0.7.2
+
+- Bug fixes:
+  - #79: We now put typst compiler and renderer in a dedicate thread. Therefore we should get more stable performance. 
+  - #78: Currently only the latest compile/render request is processed. This should fix the problem where the preview request will queue up when you type too fast and the doc takes a lot of time to compile.
+  - #81: We now use a more robust way to detect the whether to kill stale server process. This should fix the problem where the when preview tab will become blank when it becomes inactive for a while.
+  - #87: Add enum description for `typst-preview.scrollSync`. Previously the description is missing.

--- a/addons/vscode/README.md
+++ b/addons/vscode/README.md
@@ -138,3 +138,11 @@ Add preview button
   - fix #41. It is now possible to use Typst Preview in VSCode Remote.
   - fix #82. You can have preview button even when typst-lsp is not installed.
 - Misc: We downgrade the ci image for Linux to Ubuntu 20.04. This should fix the problem where the extension cannot be installed on some old Linux distros.
+
+### v0.7.2
+
+- Bug fixes:
+  - #79: We now put typst compiler and renderer in a dedicate thread. Therefore we should get more stable performance. 
+  - #78: Currently only the latest compile/render request is processed. This should fix the problem where the preview request will queue up when you type too fast and the doc takes a lot of time to compile.
+  - #81: We now use a more robust way to detect the whether to kill stale server process. This should fix the problem where the when preview tab will become blank when it becomes inactive for a while.
+  - #87: Add enum description for `typst-preview.scrollSync`. Previously the description is missing.

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/Enter-tainer/typst-preview"
   },
-  "version": "0.7.1",
+  "version": "0.7.2",
   "engines": {
     "vscode": "^1.77.0"
   },


### PR DESCRIPTION
- Bug fixes:
  - #79: We now put typst compiler and renderer in a dedicate thread. Therefore we should get more stable performance. 
  - #78: Currently only the latest compile/render request is processed. This should fix the problem where the preview request will queue up when you type too fast and the doc takes a lot of time to compile.
  - #81: We now use a more robust way to detect the whether to kill stale server process. This should fix the problem where the when preview tab will become blank when it becomes inactive for a while.
  - #87: Add enum description for `typst-preview.scrollSync`. Previously the description is missing.
