### PR TITLE
dev(frontend): add height padding and center pages

### DIFF
--- a/addons/frontend/index.html
+++ b/addons/frontend/index.html
@@ -69,7 +69,7 @@
       /// 0~1: cannot distinguish by human eyes
       /// 1~2: perceptible through close observation
       /// 2~10: perceptible at a glance
-      if (deltaE(cssColorToRgba(previewBackgroundColor), [255, 255, 255]) < 2) {
+      if (deltaE(cssColorToRgba(previewBackgroundColor), [255, 255, 255]) < 5) {
         previewBackgroundColor = defaultBackgroundColor;
       }
 

--- a/addons/frontend/index.html
+++ b/addons/frontend/index.html
@@ -4,6 +4,81 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Typst Preview</title>
+    <style id="preview-theme-styles"></style>
+    <!-- before all of code to avoid rerender by style replacement -->
+    <script>
+      /// https://stackoverflow.com/questions/13586999/color-difference-similarity-between-two-values-with-js
+      function deltaE(rgbA, rgbB) {
+        let labA = rgb2lab(rgbA);
+        let labB = rgb2lab(rgbB);
+        let deltaL = labA[0] - labB[0];
+        let deltaA = labA[1] - labB[1];
+        let deltaB = labA[2] - labB[2];
+        let c1 = Math.sqrt(labA[1] * labA[1] + labA[2] * labA[2]);
+        let c2 = Math.sqrt(labB[1] * labB[1] + labB[2] * labB[2]);
+        let deltaC = c1 - c2;
+        let deltaH = deltaA * deltaA + deltaB * deltaB - deltaC * deltaC;
+        deltaH = deltaH < 0 ? 0 : Math.sqrt(deltaH);
+        let sc = 1.0 + 0.045 * c1;
+        let sh = 1.0 + 0.015 * c1;
+        let deltaLKlsl = deltaL / 1.0;
+        let deltaCkcsc = deltaC / sc;
+        let deltaHkhsh = deltaH / sh;
+        let i =
+          deltaLKlsl * deltaLKlsl +
+          deltaCkcsc * deltaCkcsc +
+          deltaHkhsh * deltaHkhsh;
+        return i < 0 ? 0 : Math.sqrt(i);
+      }
+
+      function rgb2lab(rgb) {
+        let r = rgb[0] / 255,
+          g = rgb[1] / 255,
+          b = rgb[2] / 255,
+          x,
+          y,
+          z;
+        r = r > 0.04045 ? Math.pow((r + 0.055) / 1.055, 2.4) : r / 12.92;
+        g = g > 0.04045 ? Math.pow((g + 0.055) / 1.055, 2.4) : g / 12.92;
+        b = b > 0.04045 ? Math.pow((b + 0.055) / 1.055, 2.4) : b / 12.92;
+        x = (r * 0.4124 + g * 0.3576 + b * 0.1805) / 0.95047;
+        y = (r * 0.2126 + g * 0.7152 + b * 0.0722) / 1.0;
+        z = (r * 0.0193 + g * 0.1192 + b * 0.9505) / 1.08883;
+        x = x > 0.008856 ? Math.pow(x, 1 / 3) : 7.787 * x + 16 / 116;
+        y = y > 0.008856 ? Math.pow(y, 1 / 3) : 7.787 * y + 16 / 116;
+        z = z > 0.008856 ? Math.pow(z, 1 / 3) : 7.787 * z + 16 / 116;
+        return [116 * y - 16, 500 * (x - y), 200 * (y - z)];
+      }
+
+      // https://stackoverflow.com/questions/26414770/getting-the-rgb-values-for-a-css-html-named-color-in-javascript
+      function cssColorToRgba(cssColor) {
+        var canvas = document.createElement("canvas");
+        var context = canvas.getContext("2d");
+        context.fillStyle = cssColor;
+        context.fillRect(0, 0, 1, 1);
+        return context.getImageData(0, 0, 1, 1).data;
+      }
+
+      var defaultBackgroundColor = "rgb(82, 86, 89)";
+      var previewBackgroundColor =
+        getComputedStyle(document.documentElement).getPropertyValue(
+          "--vscode-sideBar-background"
+        ) || defaultBackgroundColor;
+
+      /// Perceptible distance between colors:
+      /// 0~1: cannot distinguish by human eyes
+      /// 1~2: perceptible through close observation
+      /// 2~10: perceptible at a glance
+      if (deltaE(cssColorToRgba(previewBackgroundColor), [255, 255, 255]) < 2) {
+        previewBackgroundColor = defaultBackgroundColor;
+      }
+
+      // append css variable --typst-preview-background-color
+      document.documentElement.style.setProperty(
+        "--typst-preview-background-color",
+        previewBackgroundColor
+      );
+    </script>
     <script type="module" src="/src/main.js"></script>
     <script type="module" src="/src/svg.ts"></script>
   </head>
@@ -12,20 +87,12 @@
     style="
       padding: 0;
       margin: 0;
-      background-color: var(
-        --vscode-sideBar-background,
-        rgb(82, 86, 89)
-      ) !important;
+      background-color: var(--typst-preview-background-color) !important;
     "
   >
     <div
       id="imageContainer"
-      style="
-        background-color: var(
-          --vscode-sideBar-background,
-          rgb(82, 86, 89)
-        ) !important;
-      "
+      style="background-color: var(--typst-preview-background-color) !important"
     ></div>
   </body>
 </html>

--- a/addons/frontend/index.html
+++ b/addons/frontend/index.html
@@ -13,7 +13,7 @@
       padding: 0;
       margin: 0;
       background-color: var(
-        --vscode-editor-background,
+        --vscode-sideBar-background,
         rgb(82, 86, 89)
       ) !important;
     "
@@ -22,7 +22,7 @@
       id="imageContainer"
       style="
         background-color: var(
-          --vscode-editor-background,
+          --vscode-sideBar-background,
           rgb(82, 86, 89)
         ) !important;
       "

--- a/addons/frontend/index.html
+++ b/addons/frontend/index.html
@@ -8,7 +8,24 @@
     <script type="module" src="/src/svg.ts"></script>
   </head>
 
-  <body style="padding: 0; margin: 0;">
-    <div id="imageContainer"></div>
+  <body
+    style="
+      padding: 0;
+      margin: 0;
+      background-color: var(
+        --vscode-editor-background,
+        rgba(0, 0, 0, 0.5)
+      ) !important;
+    "
+  >
+    <div
+      id="imageContainer"
+      style="
+        background-color: var(
+          --vscode-editor-background,
+          rgba(0, 0, 0, 0.5)
+        ) !important;
+      "
+    ></div>
   </body>
 </html>

--- a/addons/frontend/index.html
+++ b/addons/frontend/index.html
@@ -87,12 +87,18 @@
     style="
       padding: 0;
       margin: 0;
+      height: fit-content;
       background-color: var(--typst-preview-background-color) !important;
     "
   >
     <div
-      id="imageContainer"
-      style="background-color: var(--typst-preview-background-color) !important"
+      id="typst-app"
+      style="
+        width: fit-content;
+        height: fit-content;
+        margin: 0 auto;
+        background-color: var(--typst-preview-background-color) !important;
+      "
     ></div>
   </body>
 </html>

--- a/addons/frontend/index.html
+++ b/addons/frontend/index.html
@@ -14,7 +14,7 @@
       margin: 0;
       background-color: var(
         --vscode-editor-background,
-        rgba(0, 0, 0, 0.5)
+        rgb(82, 86, 89)
       ) !important;
     "
   >
@@ -23,7 +23,7 @@
       style="
         background-color: var(
           --vscode-editor-background,
-          rgba(0, 0, 0, 0.5)
+          rgb(82, 86, 89)
         ) !important;
       "
     ></div>

--- a/addons/frontend/src/main.js
+++ b/addons/frontend/src/main.js
@@ -19,7 +19,8 @@ function createSvgDocument(wasmDocRef) {
     // set rescale target to `body`
     retrieveDOMState() {
       return {
-        width: resizeTarget.clientWidth,
+        // reserving 1px to avoid initial width scrollbar
+        width: resizeTarget.clientWidth - 1,
         boundingRect: resizeTarget.getBoundingClientRect(),
       };
     },

--- a/addons/frontend/src/main.js
+++ b/addons/frontend/src/main.js
@@ -60,6 +60,7 @@ window.onload = function () {
       console.log(message[0], message[1].length);
 
       if (message[0] === "jump") {
+        // todo: aware height padding
         const [page, x, y] = dec
           .decode(message[1].buffer)
           .split(" ")

--- a/addons/frontend/src/main.js
+++ b/addons/frontend/src/main.js
@@ -11,8 +11,19 @@ const dec = new TextDecoder("utf-8");
 const NOT_AVAIABLE = "current not avalible";
 const COMMA = enc.encode(",");
 
-function createSvgDocument(hookedElem, wasmDocRef) {
-  const svgDoc = new SvgDocument(hookedElem, wasmDocRef);
+function createSvgDocument(wasmDocRef) {
+  const hookedElem = document.getElementById("typst-app");
+  const resizeTarget = document.documentElement;
+
+  const svgDoc = new SvgDocument(hookedElem, wasmDocRef, {
+    // set rescale target to `body`
+    retrieveDOMState() {
+      return {
+        width: resizeTarget.clientWidth,
+        boundingRect: resizeTarget.getBoundingClientRect(),
+      };
+    },
+  });
 
   // drag (panal resizing) -> rescaling
   // window.onresize = () => svgDoc.rescale();
@@ -66,7 +77,7 @@ window.onload = function () {
           .split(" ")
           .map(Number);
         const rootElem =
-          document.getElementById("imageContainer")?.firstElementChild;
+          document.getElementById("typst-app")?.firstElementChild;
         if (rootElem) {
           /// Note: when it is really scrolled, it will trigger `svgDoc.addViewportChange`
           /// via `window.onscroll` event
@@ -102,10 +113,7 @@ window.onload = function () {
     .then(async (kModule /* module kernel from wasm */) => {
       console.log("plugin initialized, build info:", rendererBuildInfo());
 
-      const hookedElem = document.getElementById("imageContainer");
-      const svgDoc = createSvgDocument(hookedElem, kModule);
-
       // todo: plugin init and setup socket at the same time
-      setupSocket(svgDoc);
+      setupSocket(createSvgDocument(kModule));
     });
 };

--- a/addons/frontend/src/svg-doc.ts
+++ b/addons/frontend/src/svg-doc.ts
@@ -29,7 +29,7 @@ export class SvgDocument {
 
   /// Style fields
 
-  borderColor: string;
+  backgroundColor: string;
 
   /// Cache fields
 
@@ -56,7 +56,7 @@ export class SvgDocument {
     this.hookedElem.style.transformOrigin = "0px 0px";
 
     /// Style fields
-    this.borderColor = getComputedStyle(document.documentElement).getPropertyValue('--vscode-editor-background')
+    this.backgroundColor = getComputedStyle(document.documentElement).getPropertyValue('--vscode-editor-background')
       || 'rgb(82, 86, 89)';
 
     installEditorJumpToHandler(this.kModule, this.hookedElem);
@@ -253,7 +253,7 @@ export class SvgDocument {
       outerRect.setAttribute("x", "0");
       outerRect.setAttribute("y", "0");
       // white background
-      outerRect.setAttribute("fill", this.borderColor);
+      outerRect.setAttribute("fill", this.backgroundColor);
       e.insertBefore(outerRect, firstRect);
     }
 

--- a/addons/frontend/src/svg-doc.ts
+++ b/addons/frontend/src/svg-doc.ts
@@ -56,8 +56,7 @@ export class SvgDocument {
     this.hookedElem.style.transformOrigin = "0px 0px";
 
     /// Style fields
-    this.backgroundColor = getComputedStyle(document.documentElement).getPropertyValue('--vscode-sideBar-background')
-      || 'rgb(82, 86, 89)';
+    this.backgroundColor = getComputedStyle(document.documentElement).getPropertyValue('--typst-preview-background-color');
 
     installEditorJumpToHandler(this.kModule, this.hookedElem);
     this.installCtrlWheelHandler();

--- a/addons/frontend/src/svg-doc.ts
+++ b/addons/frontend/src/svg-doc.ts
@@ -1,4 +1,4 @@
-import { patchRoot } from "./svg-patch";
+import { patchSvgToContainer } from "./svg-patch";
 import { installEditorJumpToHandler } from "./svg-debug-info";
 import { RenderSession } from "@myriaddreamin/typst.ts/dist/esm/renderer";
 
@@ -328,17 +328,7 @@ export class SvgDocument {
     }
 
     const t2 = performance.now();
-
-    if (this.hookedElem.firstElementChild) {
-      const elem = document.createElement("div");
-      elem.innerHTML = patchStr;
-      const svgElement = elem.firstElementChild as SVGElement;
-      this.decorateSvgElement(svgElement!);
-      patchRoot(this.hookedElem.firstElementChild as SVGElement, svgElement);
-    } else {
-      this.hookedElem.innerHTML = patchStr;
-      this.decorateSvgElement(this.hookedElem.firstElementChild! as SVGElement);
-    }
+    patchSvgToContainer(this.hookedElem, patchStr, (elem) => this.decorateSvgElement(elem));
     const t3 = performance.now();
 
     return [t2, t3];

--- a/addons/frontend/src/svg-doc.ts
+++ b/addons/frontend/src/svg-doc.ts
@@ -56,7 +56,7 @@ export class SvgDocument {
     this.hookedElem.style.transformOrigin = "0px 0px";
 
     /// Style fields
-    this.backgroundColor = getComputedStyle(document.documentElement).getPropertyValue('--vscode-editor-background')
+    this.backgroundColor = getComputedStyle(document.documentElement).getPropertyValue('--vscode-sideBar-background')
       || 'rgb(82, 86, 89)';
 
     installEditorJumpToHandler(this.kModule, this.hookedElem);
@@ -212,17 +212,22 @@ export class SvgDocument {
       const translateAttr = `translate(${calculatedPaddedX}, ${calculatedPaddedY})`;
 
       /// Create inner rectangle
+      const INNER_RECT_UNIT = 100;
       const innerRect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
       innerRect.setAttribute("class", "typst-page-inner");
       innerRect.setAttribute("data-page-width", pageWidth.toString());
       innerRect.setAttribute("data-page-height", pageHeight.toString());
-      innerRect.setAttribute("width", Math.floor((pageWidth - backgroundHideFactor) * 100).toString());
-      innerRect.setAttribute("height", Math.floor((pageHeight - backgroundHideFactor) * 100).toString());
+      innerRect.setAttribute("width", Math.floor((pageWidth - backgroundHideFactor) * INNER_RECT_UNIT).toString());
+      innerRect.setAttribute("height", Math.floor((pageHeight - backgroundHideFactor) * INNER_RECT_UNIT).toString());
       innerRect.setAttribute("x", "0");
       innerRect.setAttribute("y", "0");
       innerRect.setAttribute("transform", `${translateAttr} scale(0.01)`);
       // white background
       innerRect.setAttribute("fill", "white");
+      // It is quite ugly
+      // innerRect.setAttribute("stroke", "black");
+      // innerRect.setAttribute("stroke-width", (2 * INNER_RECT_UNIT * scale).toString());
+      // innerRect.setAttribute("stroke-opacity", "0.4");
 
       /// Move page to the correct position
       nextPage.setAttribute("transform", translateAttr);

--- a/addons/frontend/src/svg-doc.ts
+++ b/addons/frontend/src/svg-doc.ts
@@ -57,7 +57,7 @@ export class SvgDocument {
 
     /// Style fields
     this.borderColor = getComputedStyle(document.documentElement).getPropertyValue('--vscode-editor-background')
-      || 'rgba(0, 0, 0, 0.5)';
+      || 'rgb(82, 86, 89)';
 
     installEditorJumpToHandler(this.kModule, this.hookedElem);
     this.installCtrlWheelHandler();

--- a/addons/frontend/src/svg-doc.ts
+++ b/addons/frontend/src/svg-doc.ts
@@ -156,10 +156,6 @@ export class SvgDocument {
 
   // Note: one should retrieve dom state before rescale
   rescale() {
-    // hide: white unaligned page
-    // todo: better solution
-    const widthHideFactor = 1e-3;
-
     // get dom state from cache, so we are free from layout reflowing
     // Note: one should retrieve dom state before rescale
     const { width: containerWidth } = this.cachedDOMState;
@@ -169,7 +165,7 @@ export class SvgDocument {
     const svgWidth = Number.parseFloat(
       svg.getAttribute("data-width") || svg.getAttribute("width") || "1"
     );
-    this.currentRealScale = this.currentContainerWidth / svgWidth + widthHideFactor;
+    this.currentRealScale = this.currentContainerWidth / svgWidth;
     this.currentContainerWidth = containerWidth;
 
     const scale = this.currentRealScale * this.currentScaleRatio;
@@ -217,7 +213,7 @@ export class SvgDocument {
     // 5px height margin, 0px width margin (it is buggy to add width margin)
     const heightMargin = 5 * scale;
     const widthMargin = 0;
-    const newWidth = Number.parseFloat(width) + 2 * widthMargin + 1e-5;
+    const newWidth = Number.parseFloat(width) + 2 * widthMargin;
 
     /// Apply new pages
     let accumulatedHeight = 0;
@@ -231,8 +227,7 @@ export class SvgDocument {
       const pageHeight = Number.parseFloat(nextPage.getAttribute("data-page-height")!);
 
       /// center the page and add margin
-      const calculatedPaddedXRough = (newWidth - pageWidth) / 2;
-      const calculatedPaddedX = Math.abs(calculatedPaddedXRough) < 1e-3 ? 0 : calculatedPaddedXRough;
+      const calculatedPaddedX = (newWidth - pageWidth) / 2;
       const calculatedPaddedY = accumulatedHeight + (i == 0 ? 0 : heightMargin);
       const translateAttr = `translate(${calculatedPaddedX}, ${calculatedPaddedY})`;
 
@@ -287,14 +282,12 @@ export class SvgDocument {
       svg.insertBefore(outerRect, firstRect);
     }
 
-    // hide unaligned width
-    const newWidthFloor = newWidth - 1e-5;
-    const newHeightFloor = newHeight - 1e-5;
-    svg.setAttribute("viewBox", `0 0 ${newWidthFloor} ${newHeightFloor}`);
-    svg.setAttribute("width", `${newWidthFloor}`);
-    svg.setAttribute("height", `${newHeightFloor}`);
-    svg.setAttribute("data-width", `${newWidthFloor}`);
-    svg.setAttribute("data-height", `${newHeightFloor}`);
+    /// Update svg width, height information
+    svg.setAttribute("viewBox", `0 0 ${newWidth} ${newHeight}`);
+    svg.setAttribute("width", `${newWidth}`);
+    svg.setAttribute("height", `${newHeight}`);
+    svg.setAttribute("data-width", `${newWidth}`);
+    svg.setAttribute("data-height", `${newHeight}`);
   }
 
   private toggleViewportChange() {

--- a/addons/frontend/src/svg-patch.ts
+++ b/addons/frontend/src/svg-patch.ts
@@ -469,12 +469,16 @@ function reuseOrPatchElem(prev: SVGGElement, next: SVGGElement) {
 
 interface FrozenReplacement {
   inserts: Element[][];
+  debug?: string;
 }
 
 function preReplaceNonSVGElements(prev: Element, next: Element, since: number): FrozenReplacement {
   const removedIndecies = [];
   const frozenReplacement: FrozenReplacement = {
     inserts: [],
+    //     debug: `preReplaceNonSVGElements ${since}
+    // prev: ${prev.outerHTML}
+    // next: ${next.outerHTML}`
   };
   for (let i = since; i < prev.children.length; i++) {
     const prevChild = prev.children[i];
@@ -508,7 +512,8 @@ function postReplaceNonSVGElements(prev: Element, since: number, frozen: FrozenR
   /// Retrive the `<g>` elements from the `prev` element.
   const gElements = Array.from(prev.children).slice(since).filter(isGElem);
   if (gElements.length + 1 !== frozen.inserts.length) {
-    throw new Error("invalid frozen replacement");
+    throw new Error(`invalid frozen replacement: gElements.length (${gElements.length}) + 1 !=== frozen.inserts.length (${frozen.inserts.length}) ${frozen.debug || ''}
+current: ${prev.outerHTML}`);
   }
 
   /// Insert the separated elements to the `prev` element.

--- a/addons/frontend/src/svg-patch.ts
+++ b/addons/frontend/src/svg-patch.ts
@@ -332,10 +332,10 @@ function patchRoot(prev: SVGElement, next: SVGElement) {
   patchAttributes(prev, next);
 
   /// Hard replace elements that is not a `<g>` element.
-  const frozen = preReplaceNonSVGElements(prev, next, 0);
+  const frozen = preReplaceNonSVGElements(prev, next);
   /// Patch `<g>` children, call `reuseOrPatchElem` to patch.
   patchChildren(prev, next);
-  postReplaceNonSVGElements(prev, 0, frozen);
+  postReplaceNonSVGElements(prev, frozen);
   return;
 }
 
@@ -414,10 +414,10 @@ function reuseOrPatchElem(prev: SVGGElement, next: SVGGElement) {
   }
 
   /// Hard replace elements that is not a `<g>` element.
-  const frozen = preReplaceNonSVGElements(prev, next, 0);
+  const frozen = preReplaceNonSVGElements(prev, next);
   /// Patch `<g>` children, will call `reuseOrPatchElem` again.
   patchChildren(prev, next);
-  postReplaceNonSVGElements(prev, 0, frozen);
+  postReplaceNonSVGElements(prev, frozen);
   return false /* reused */;
 }
 
@@ -426,7 +426,7 @@ interface FrozenReplacement {
   debug?: string;
 }
 
-function preReplaceNonSVGElements(prev: Element, next: Element, since: number): FrozenReplacement {
+function preReplaceNonSVGElements(prev: Element, next: Element): FrozenReplacement {
   const removedIndecies = [];
   const frozenReplacement: FrozenReplacement = {
     inserts: [],
@@ -434,7 +434,7 @@ function preReplaceNonSVGElements(prev: Element, next: Element, since: number): 
     // prev: ${prev.outerHTML}
     // next: ${next.outerHTML}`
   };
-  for (let i = since; i < prev.children.length; i++) {
+  for (let i = 0; i < prev.children.length; i++) {
     const prevChild = prev.children[i];
     if (!isGElem(prevChild)) {
       removedIndecies.push(i);
@@ -446,7 +446,7 @@ function preReplaceNonSVGElements(prev: Element, next: Element, since: number): 
   }
 
   let elements: Element[] = [];
-  for (let i = since; i < next.children.length; i++) {
+  for (let i = 0; i < next.children.length; i++) {
     const nextChild = next.children[i];
     if (!isGElem(nextChild)) {
       elements.push(nextChild);
@@ -461,10 +461,10 @@ function preReplaceNonSVGElements(prev: Element, next: Element, since: number): 
   return frozenReplacement;
 }
 
-function postReplaceNonSVGElements(prev: Element, since: number, frozen: FrozenReplacement) {
+function postReplaceNonSVGElements(prev: Element, frozen: FrozenReplacement) {
 
   /// Retrive the `<g>` elements from the `prev` element.
-  const gElements = Array.from(prev.children).slice(since).filter(isGElem);
+  const gElements = Array.from(prev.children).filter(isGElem);
   if (gElements.length + 1 !== frozen.inserts.length) {
     throw new Error(`invalid frozen replacement: gElements.length (${gElements.length}) + 1 !=== frozen.inserts.length (${frozen.inserts.length}) ${frozen.debug || ''}
 current: ${prev.outerHTML}`);

--- a/addons/frontend/src/svg.ts
+++ b/addons/frontend/src/svg.ts
@@ -37,11 +37,11 @@ var overLapping = function (a: Element, b: Element) {
     ) &&
     /// determine overlapping by area
     (Math.abs(aRect.left - bRect.left) + Math.abs(aRect.right - bRect.right)) /
-      Math.max(aRect.width, bRect.width) <
-      0.5 &&
+    Math.max(aRect.width, bRect.width) <
+    0.5 &&
     (Math.abs(aRect.bottom - bRect.bottom) + Math.abs(aRect.top - bRect.top)) /
-      Math.max(aRect.height, bRect.height) <
-      0.5
+    Math.max(aRect.height, bRect.height) <
+    0.5
   );
 };
 

--- a/addons/frontend/src/typst.css
+++ b/addons/frontend/src/typst.css
@@ -2,7 +2,7 @@ body {
   background-color: #fff;
 }
 
-#imageContainer {
+#typst-app {
   margin: 0;
   transform-origin: 0 0;
   background-color: #fff;


### PR DESCRIPTION
Without help of upstream typst.ts, It is still easier than imagined to decorate pages.

Though we leave customization out of current PR, I believe we have a good default setting:
+ The border width is window-aware.
+ The color page's border (page break) is fixed in `--vscode-editor-background`.
+ The page's background is fixed in `white` color, but you can still override a background at typst side, as the screenshot shown.
  via `set page(fill: rgb("#1a1b26").lighten(10%))`.
  
  
![image](https://github.com/Enter-tainer/typst-preview/assets/35292584/7d1adade-454b-4afb-9832-fb29d62d0b81)

fix #125 fix #122 fix #80 
