### PR TITLE
fix(frontend): correct `appendOffset` calculation

### DIFF
--- a/addons/frontend/src/svg-patch.test.ts
+++ b/addons/frontend/src/svg-patch.test.ts
@@ -327,4 +327,41 @@ describe("interpretView", () => {
       []
     `);
   });
+
+  it("handleReuseAppend", () => {
+    const origin = injectOffsets("o", repeatOrJust([null, null, null, 0, 1]));
+    const target = injectOffsets("t", [1, null, 0, null, 1].map(reuseStub));
+    const result = interpretTargetView<MockElement>(
+      origin, target,
+      hasTid,
+    );
+    const result2 = changeViewPerspective<MockElement>(origin,
+      result[0],
+      hasTid,
+    );
+    expect(toSnapshot(result)).toMatchInlineSnapshot(`
+      [
+        "reuse,4",
+        "append,t1",
+        "reuse,3",
+        "append,t3",
+        "append,t4",
+        "o1->t0,o0->t2",
+      ]
+    `);
+
+    // after swap_in,3,4: [o0, o1, o2, o4(1), o3(0)]
+    // insert,4,t1: [o0, o1, o2, o4(1), t1, o3(0)]
+    // insert,6,t3: [o0, o1, o2, o4(1), t1, o3(0), t3]
+    // insert,7,t4: [o0, o1, o2, o4(1), t1, o3(0), t3, t4]
+    // with patch: [o0, o1, o2, t0, t1, t2, t3, t4]
+    expect(toSnapshot([result2, []])).toMatchInlineSnapshot(`
+      [
+        "swap_in,3,4",
+        "insert,4,t1",
+        "insert,6,t3",
+        "insert,7,t4",
+      ]
+    `);
+  });
 });

--- a/addons/frontend/src/svg-patch.ts
+++ b/addons/frontend/src/svg-patch.ts
@@ -266,6 +266,7 @@ export function changeViewPerspective<
     if (!tIsU(prevChild)) {
       const target_off = getShift(off);
       swapIns.push(target_off);
+      appendOffset++;
       continue;
     }
 


### PR DESCRIPTION

The bug is more easily to observe with #117 not merged, because an empty main file causes single empty page to insert and then the main file recovery causes a bundle of pages to insert.

## Bug Reproduce

When appending pages, the svg patches become unreliable on preserving order of elements other that `<g/>`. To trigger it:

```typst
#set page(height: 60pt)
#lorem(30) // append (to ensure that fresh pages appended)
#lorem(30) // append
#lorem(30) // append
#lorem(30) // append
#lorem(30) // append
#lorem(30) // append
#text(fill: red, "123") // never patch color anymore, so it is black because of bug
#text(fill: blue, "123") // never patch color anymore, so it is black because of bug
```

## Possible behavior

Preview will have following behavior because of bug:

### glyph resources desync (never happens)

What is interesting is that the first element of `<svg/>` is never affected, so that preview can always show all glyphs. This is because the document always has at least one page initially.

### clip path resources desync (chance to #94)

The resources are stored in the second element of `<svg/>` will never get updated. This may heavily affect the elements to show correctly across pages, such as cross-page tables.

### color resources desync (chance to #104)

The resources stored in the third element of `<svg/>` will never get updated. One may have change to see that new colors are not effective applied (but old colors are still available).

### page out of order (not observable)

It is interesting (but not good) that, the patcher will recover the order of pages after a second patch request coming.

## Testcase description

As shown in testcase `handleMasterproefThesisAffectedByEmptyPage`, with bug fixing, it will become:

```jsonc
[ "insert,1,t0" ] // before
[ "insert,4,t0" ] // after
```

I also construct another case `handleMasterproefThesisAffectedByEmptyPageAntiCase`. The patcher works occasionally since all of pages reuse corresponding `<g/>` elements and no DOM update happens.





