### PR TITLE
Removed `Some()` wrapper in output of `--version`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -51,21 +51,22 @@ pub struct CliArguments {
     pub input: PathBuf,
 }
 
+static NONE: &str = "None";
 static LONG_VERSION: Lazy<String> = Lazy::new(|| {
     format!(
         "
 Build Timestamp:     {}
 Build Git Discribe:  {}
-Commit SHA:          {:?}
-Commit Date:         {:?}
-Commit Branch:       {:?}
+Commit SHA:          {}
+Commit Date:         {}
+Commit Branch:       {}
 Cargo Target Triple: {}
 ",
         env!("VERGEN_BUILD_TIMESTAMP"),
         env!("VERGEN_GIT_DESCRIBE"),
-        option_env!("VERGEN_GIT_SHA"),
-        option_env!("VERGEN_GIT_COMMIT_TIMESTAMP"),
-        option_env!("VERGEN_GIT_BRANCH"),
+        option_env!("VERGEN_GIT_SHA").unwrap_or(NONE),
+        option_env!("VERGEN_GIT_COMMIT_TIMESTAMP").unwrap_or(NONE),
+        option_env!("VERGEN_GIT_BRANCH").unwrap_or(NONE),
         env!("VERGEN_CARGO_TARGET_TRIPLE"),
     )
 });

--- a/src/args.rs
+++ b/src/args.rs
@@ -56,7 +56,7 @@ static LONG_VERSION: Lazy<String> = Lazy::new(|| {
     format!(
         "
 Build Timestamp:     {}
-Build Git Discribe:  {}
+Build Git Describe:  {}
 Commit SHA:          {}
 Commit Date:         {}
 Commit Branch:       {}


### PR DESCRIPTION
In #146 a version option was added. With `--version` the output looks like this:

```
typst-preview 
Build Timestamp:     2023-10-20T15:09:33.160241155Z
Build Git Discribe:  v0.8.2
Commit SHA:          Some("bfedf21f594364071003b98ff8992d34f7100a2a")
Commit Date:         None
Commit Branch:       None
Cargo Target Triple: x86_64-unknown-linux-gnu
```

With this PR it looks more readable:

```
typst-preview 
Build Timestamp:     2023-10-20T17:25:58.472998064Z
Build Git Discribe:  v0.8.2-1-ge949869
Commit SHA:          e949869b8a2e14958ce0eb142dedf15b37acc19f
Commit Date:         None
Commit Branch:       None
Cargo Target Triple: x86_64-unknown-linux-gnu
```

I thought about 3 or 5 different ways of unwrapping a `&'static str` from `Some()` while saving the `None` if environment variable is not set. This is the cleanest way, so I chose it. The only problem, that I can solve with other ways is to get `None` and stringify it instead of assuming that `None` will be converted as `"None"`. In current stable version (v1) of Rust this won't be an issue, but maaaaybe in the second it will change. But since it's highly unlikely, I hard-coded the `"None"` directly.
