### PR TITLE
feat: content preview and navigation in sidebar of VSCode

### DIFF
--- a/addons/frontend/src/main.js
+++ b/addons/frontend/src/main.js
@@ -10,13 +10,58 @@ let previewModePlaceholder = 'preview-arg:previewMode:Doc';
 previewModePlaceholder = previewModePlaceholder.replace('preview-arg:previewMode:', '');
 let previewMode = PreviewMode[previewModePlaceholder];
 
-window.onload = () => wsMain(previewMode);
+let previousDispose = Promise.resolve(() => {});
+window.onload = () => nextWs({
+    url: "ws://127.0.0.1:23625", 
+    previewMode, 
+    isContentPreview: false,
+});
 
-const app = document.getElementById('typst-container');
-if (previewMode === PreviewMode.Slide) {
-    app.classList.add('mode-slide');
-} else if (previewMode === PreviewMode.Doc) {
-    app.classList.add('mode-doc');
-} else {
-    throw new Error(`Unknown preview mode: ${previewMode}`);
+const vscodeAPI = (typeof acquireVsCodeApi !== 'undefined') && acquireVsCodeApi();
+if (vscodeAPI?.postMessage) {
+    vscodeAPI.postMessage({ type: 'started' });
+}
+
+// Handle messages sent from the extension to the webview
+window.addEventListener('message', event => {
+    const message = event.data; // The json data that the extension sent
+    switch (message.type) {
+        case 'reconnect': {
+            console.log('reconnect', message);
+            nextWs({
+                url:  message.url, 
+                previewMode: PreviewMode[message.mode], 
+                isContentPreview: message.isContentPreview,
+            });
+            break;
+        }
+    }
+});
+
+function nextWs(nextWsArgs) {
+    const previous = previousDispose;
+    previousDispose = new Promise(async (resolve) => {
+        await previous.then(d => d());
+        resetContainer(nextWsArgs);
+        resolve(wsMain(nextWsArgs));
+    });
+}
+
+function resetContainer({ previewMode: mode, isContentPreview }) {
+    const app = document.getElementById('typst-container');
+    app.classList.remove('mode-slide');
+    app.classList.remove('mode-doc');
+    app.classList.remove('content-preview');
+
+   if (isContentPreview) {
+        app.classList.add('content-preview');
+   }
+   
+   if (mode === PreviewMode.Slide) {
+        app.classList.add('mode-slide');
+    } else if (mode === PreviewMode.Doc) {
+        app.classList.add('mode-doc');
+    } else {
+        throw new Error(`Unknown preview mode: ${mode}`);
+    }
 }

--- a/addons/frontend/src/main.js
+++ b/addons/frontend/src/main.js
@@ -1,3 +1,6 @@
+
+/// Import stylesheets for different components
+// todo: refactor them, but we don't touch them in this PR
 import "./typst.css";
 import "./styles/toolbar.css";
 import "./styles/layout.css";
@@ -6,66 +9,105 @@ import "./styles/help-panel.css";
 import { wsMain } from './ws';
 import { PreviewMode } from './svg-doc';
 
-let previewModePlaceholder = 'preview-arg:previewMode:Doc';
-previewModePlaceholder = previewModePlaceholder.replace('preview-arg:previewMode:', '');
-let previewMode = PreviewMode[previewModePlaceholder];
+/// Main entry point of the frontend program.
+main();
 
-let previousDispose = Promise.resolve(() => {});
-window.onload = () => nextWs({
-    url: "ws://127.0.0.1:23625", 
-    previewMode, 
-    isContentPreview: false,
-});
-
-const vscodeAPI = (typeof acquireVsCodeApi !== 'undefined') && acquireVsCodeApi();
-if (vscodeAPI?.postMessage) {
-    vscodeAPI.postMessage({ type: 'started' });
+function main() {
+    const wsArgs = retrieveWsArgs();
+    const { nextWs } = buildWs();
+    window.onload = () => nextWs(wsArgs);
+    setupVscodeChannel(nextWs);
 }
 
-// Handle messages sent from the extension to the webview
-window.addEventListener('message', event => {
-    const message = event.data; // The json data that the extension sent
-    switch (message.type) {
-        case 'reconnect': {
-            console.log('reconnect', message);
-            nextWs({
-                url:  message.url, 
-                previewMode: PreviewMode[message.mode], 
-                isContentPreview: message.isContentPreview,
-            });
-            break;
+/// Placeholders for typst-preview program initializing frontend
+/// arguments.
+function retrieveWsArgs() {
+    /// The string `preview-arg:previewMode:Doc` is a placeholder
+    /// It will be replaced by the actual preview mode.
+    /// ```rs
+    ///   let frontend_html = frontend_html.replace(
+    ///     "preview-arg:previewMode:Doc", ...);
+    /// ```
+    let mode = 'preview-arg:previewMode:Doc';
+    /// Remove the placeholder prefix.
+    mode = mode.replace('preview-arg:previewMode:', '');
+    let previewMode = PreviewMode[mode];
+
+    /// The string `ws://127.0.0.1:23625` is a placeholder
+    /// Also, it is the default url to connect to.
+    let url = "ws://127.0.0.1:23625";
+
+    /// Return a `WsArgs` object.
+    return { url, previewMode, isContentPreview: false };
+}
+
+/// `buildWs` returns a object, which keeps track of websocket
+///  connections.
+function buildWs() {
+    let previousDispose = Promise.resolve(() => { });
+    /// `nextWs` will always hold a global unique websocket connection
+    /// to the preview backend.
+    function nextWs(nextWsArgs) {
+        const previous = previousDispose;
+        previousDispose = new Promise(async (resolve) => {
+            /// Dispose the previous websocket connection.
+            await previous.then(d => d());
+            /// Reset app mode before creating a new websocket connection.
+            resetAppMode(nextWsArgs);
+            /// Create a new websocket connection.
+            resolve(wsMain(nextWsArgs));
+        });
+    }
+
+    return { nextWs };
+
+    function resetAppMode({ previewMode: mode, isContentPreview }) {
+        const app = document.getElementById('typst-container');
+
+        /// Set the root css selector to the content preview mode.
+        app.classList.remove('content-preview');
+        if (isContentPreview) {
+            app.classList.add('content-preview');
         }
-        case 'outline': {
-            console.log('outline', message);
-            break;
+
+        /// Set the root css selector to the preview mode.
+        app.classList.remove('mode-slide');
+        app.classList.remove('mode-doc');
+        if (mode === PreviewMode.Slide) {
+            app.classList.add('mode-slide');
+        } else if (mode === PreviewMode.Doc) {
+            app.classList.add('mode-doc');
+        } else {
+            throw new Error(`Unknown preview mode: ${mode}`);
         }
     }
-});
+}
 
-function nextWs(nextWsArgs) {
-    const previous = previousDispose;
-    previousDispose = new Promise(async (resolve) => {
-        await previous.then(d => d());
-        resetContainer(nextWsArgs);
-        resolve(wsMain(nextWsArgs));
+/// A frontend will try to setup a vscode channel if it is running
+/// in vscode.
+function setupVscodeChannel(nextWs) {
+    const vscodeAPI = (typeof acquireVsCodeApi !== 'undefined') && acquireVsCodeApi();
+    if (vscodeAPI?.postMessage) {
+        vscodeAPI.postMessage({ type: 'started' });
+    }
+
+    // Handle messages sent from the extension to the webview
+    window.addEventListener('message', event => {
+        const message = event.data; // The json data that the extension sent
+        switch (message.type) {
+            case 'reconnect': {
+                console.log('reconnect', message);
+                nextWs({
+                    url: message.url,
+                    previewMode: PreviewMode[message.mode],
+                    isContentPreview: message.isContentPreview,
+                });
+                break;
+            }
+            case 'outline': {
+                console.log('outline', message);
+                break;
+            }
+        }
     });
-}
-
-function resetContainer({ previewMode: mode, isContentPreview }) {
-    const app = document.getElementById('typst-container');
-    app.classList.remove('mode-slide');
-    app.classList.remove('mode-doc');
-    app.classList.remove('content-preview');
-
-   if (isContentPreview) {
-        app.classList.add('content-preview');
-   }
-   
-   if (mode === PreviewMode.Slide) {
-        app.classList.add('mode-slide');
-    } else if (mode === PreviewMode.Doc) {
-        app.classList.add('mode-doc');
-    } else {
-        throw new Error(`Unknown preview mode: ${mode}`);
-    }
 }

--- a/addons/frontend/src/main.js
+++ b/addons/frontend/src/main.js
@@ -35,6 +35,10 @@ window.addEventListener('message', event => {
             });
             break;
         }
+        case 'outline': {
+            console.log('outline', message);
+            break;
+        }
     }
 });
 

--- a/addons/frontend/src/styles/layout.css
+++ b/addons/frontend/src/styles/layout.css
@@ -15,11 +15,26 @@
   overflow: hidden;
 }
 
+#typst-container {
+  --main-margin: 0px;
+}
+
 #typst-container.mode-doc {
   width: fit-content;
   height: fit-content;
   margin: 0 auto;
   margin-top: -1px;
+}
+
+#typst-container.content-preview {
+  --main-margin: 20px;
+  margin-top: calc(var(--main-margin) / 2);
+}
+
+#typst-container.content-preview svg {
+  image-rendering: optimizeSpeed;
+  shape-rendering: optimizeSpeed;
+  text-rendering: optimizeSpeed;
 }
 
 #typst-container.mode-doc #typst-top-toolbar {

--- a/addons/frontend/src/styles/layout.css
+++ b/addons/frontend/src/styles/layout.css
@@ -48,6 +48,7 @@
 
 #typst-container.mode-doc #typst-container-main {
   width: calc(100% - (2 * var(--main-margin)));
+  margin: 0 calc(var(--main-margin));
 }
 
 #typst-container.mode-slide {

--- a/addons/frontend/src/svg-debug-info.ts
+++ b/addons/frontend/src/svg-debug-info.ts
@@ -66,6 +66,7 @@ export function removeSourceMappingHandler(docRoot: HTMLElement) {
   const prevSourceMappingHandler = (docRoot as any).sourceMappingHandler;
   if (prevSourceMappingHandler) {
     docRoot.removeEventListener("click", prevSourceMappingHandler);
+    delete (docRoot as any).sourceMappingHandler;
     // console.log("remove removeSourceMappingHandler");
   }
 }

--- a/addons/frontend/src/svg-doc.ts
+++ b/addons/frontend/src/svg-doc.ts
@@ -85,7 +85,10 @@ export class SvgDocument {
       this.previewMode = options?.previewMode;
     }
     this.isContentPreview = options?.isContentPreview || false;
-    void (this.isContentPreview);
+    if (this.isContentPreview) {
+      // content preview has very bad performance without partial rendering
+      this.partialRendering = true;
+    }
 
     /// State fields
     this.svgUpdating = false;
@@ -727,9 +730,6 @@ export class SvgDocument {
   }
 
   addChangement(change: [string, string]) {
-    if (!this.partialRendering && change[0] === "viewport-change") {
-      return;
-    }
     if (change[0] === "new") {
       this.patchQueue.splice(0, this.patchQueue.length);
     }

--- a/addons/frontend/src/typst.css
+++ b/addons/frontend/src/typst.css
@@ -38,6 +38,15 @@ body {
   background-color: #fff;
 }
 
+.typst-preview-page-number {
+  fill: var(--typst-preview-toolbar-fg-color);
+  font-family: sans-serif;
+  /* set to alignment center */
+  text-anchor: middle;
+  /* set to alignment center */
+  dominant-baseline: central;
+}
+
 .hide-scrollbar-x {
   overflow-x: hidden;
 }

--- a/addons/vscode/icons/activity-bar.svg
+++ b/addons/vscode/icons/activity-bar.svg
@@ -1,0 +1,19 @@
+<!-- https://danmarshall.github.io/google-font-to-svg-path/ -->
+<!-- Font: IBM Plex Serif -->
+<svg width="69.8" height="69.8" viewBox="-7.3 0 69.8 69.8" xmlns="http://www.w3.org/2000/svg">
+  <g
+    id="svgGroup"
+    stroke-linecap="round"
+    fill-rule="evenodd"
+    font-size="9pt"
+    stroke="#000"
+    stroke-width="0.25mm"
+    fill="#000"
+    style="stroke: #000; stroke-width: 0.25mm; fill: #000"
+  >
+    <path
+      d="M 15.9 69.8 L 15.9 68 L 26.5 68 L 26.5 1.8 L 2.1 1.8 L 2.1 14.8 L 0 14.8 L 0 0 L 55.2 0 L 55.2 14.8 L 53.1 14.8 L 53.1 1.8 L 28.7 1.8 L 28.7 68 L 39.3 68 L 39.3 69.8 L 15.9 69.8 Z"
+      vector-effect="non-scaling-stroke"
+    />
+  </g>
+</svg>

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -102,7 +102,7 @@
         {
           "id": "typst-preview.content-preview",
           "type": "webview",
-          "name": "Content Preview",
+          "name": "Content",
           "when": "config.typst-preview.showInActivityBar"
         },
         {

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -106,7 +106,6 @@
         },
         {
           "id": "typst-preview.outline",
-          "type": "webview",
           "name": "Outline"
         }
       ]

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -168,7 +168,7 @@
           "default": false
         },
         "typst-preview.showInActivityBar": {
-          "description": "(Experimental) Show typst preview's view containers in activity bar.",
+          "description": "(Experimental) Show a preview panel in activity bar.",
           "type": "boolean",
           "default": false
         },

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -88,6 +88,29 @@
         }
       ]
     },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "typst-preview-activitybar",
+          "title": "Typst Preview",
+          "icon": "./icons/activity-bar.svg"
+        }
+      ]
+    },
+    "views": {
+      "typst-preview-activitybar": [
+        {
+          "id": "typst-preview.content-preview",
+          "type": "webview",
+          "name": "Content Preview"
+        },
+        {
+          "id": "typst-preview.outline",
+          "type": "webview",
+          "name": "Outline"
+        }
+      ]
+    },
     "configuration": {
       "title": "Typst Preview",
       "properties": {

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -102,11 +102,13 @@
         {
           "id": "typst-preview.content-preview",
           "type": "webview",
-          "name": "Content Preview"
+          "name": "Content Preview",
+          "when": "config.typst-preview.showInActivityBar"
         },
         {
           "id": "typst-preview.outline",
-          "name": "Outline"
+          "name": "Outline",
+          "when": "config.typst-preview.showInActivityBar"
         }
       ]
     },
@@ -162,6 +164,11 @@
         },
         "typst-preview.cursorIndicator": {
           "description": "(Experimental) Show typst cursor indicator in preview.",
+          "type": "boolean",
+          "default": false
+        },
+        "typst-preview.showInActivityBar": {
+          "description": "(Experimental) Show typst preview's view containers in activity bar.",
           "type": "boolean",
           "default": false
         },

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -1,4 +1,5 @@
 pub mod editor;
+mod outline;
 pub mod render;
 pub mod typst;
 pub mod webview;

--- a/src/actor/outline.rs
+++ b/src/actor/outline.rs
@@ -1,0 +1,161 @@
+use std::num::NonZeroUsize;
+
+use typst::{
+    doc::Position,
+    geom::Smart,
+    model::{Content, Introspector},
+};
+use typst_ts_core::TypstDocument;
+
+use super::webview::CursorPosition;
+
+/// A heading in the outline panel.
+#[derive(Debug, Clone)]
+pub(crate) struct HeadingNode {
+    element: Content,
+    position: Position,
+    level: NonZeroUsize,
+    bookmarked: bool,
+    children: Vec<HeadingNode>,
+}
+
+/// Construct the outline for the document.
+pub(crate) fn get_outline(introspector: &mut Introspector) -> Option<Vec<HeadingNode>> {
+    let mut tree: Vec<HeadingNode> = vec![];
+
+    // Stores the level of the topmost skipped ancestor of the next bookmarked
+    // heading. A skipped heading is a heading with 'bookmarked: false', that
+    // is, it is not added to the PDF outline, and so is not in the tree.
+    // Therefore, its next descendant must be added at its level, which is
+    // enforced in the manner shown below.
+    let mut last_skipped_level = None;
+    let selector = typst::eval::LANG_ITEMS.get().unwrap().heading_elem.select();
+    for heading in introspector.query(&selector).iter() {
+        let leaf = HeadingNode::leaf(introspector, (**heading).clone());
+
+        if leaf.bookmarked {
+            let mut children = &mut tree;
+
+            // Descend the tree through the latest bookmarked heading of each
+            // level until either:
+            // - you reach a node whose children would be brothers of this
+            // heading (=> add the current heading as a child of this node);
+            // - you reach a node with no children (=> this heading probably
+            // skipped a few nesting levels in Typst, or one or more ancestors
+            // of this heading weren't bookmarked, so add it as a child of this
+            // node, which is its deepest bookmarked ancestor);
+            // - or, if the latest heading(s) was(/were) skipped
+            // ('bookmarked: false'), then stop if you reach a node whose
+            // children would be brothers of the latest skipped heading
+            // of lowest level (=> those skipped headings would be ancestors
+            // of the current heading, so add it as a 'brother' of the least
+            // deep skipped ancestor among them, as those ancestors weren't
+            // added to the bookmark tree, and the current heading should not
+            // be mistakenly added as a descendant of a brother of that
+            // ancestor.)
+            //
+            // That is, if you had a bookmarked heading of level N, a skipped
+            // heading of level N, a skipped heading of level N + 1, and then
+            // a bookmarked heading of level N + 2, that last one is bookmarked
+            // as a level N heading (taking the place of its topmost skipped
+            // ancestor), so that it is not mistakenly added as a descendant of
+            // the previous level N heading.
+            //
+            // In other words, a heading can be added to the bookmark tree
+            // at most as deep as its topmost skipped direct ancestor (if it
+            // exists), or at most as deep as its actual nesting level in Typst
+            // (not exceeding whichever is the most restrictive depth limit
+            // of those two).
+            while children.last().map_or(false, |last| {
+                last_skipped_level.map_or(true, |l| last.level < l) && last.level < leaf.level
+            }) {
+                children = &mut children.last_mut().unwrap().children;
+            }
+
+            // Since this heading was bookmarked, the next heading, if it is a
+            // child of this one, won't have a skipped direct ancestor (indeed,
+            // this heading would be its most direct ancestor, and wasn't
+            // skipped). Therefore, it can be added as a child of this one, if
+            // needed, following the usual rules listed above.
+            last_skipped_level = None;
+            children.push(leaf);
+        } else if last_skipped_level.map_or(true, |l| leaf.level < l) {
+            // Only the topmost / lowest-level skipped heading matters when you
+            // have consecutive skipped headings (since none of them are being
+            // added to the bookmark tree), hence the condition above.
+            // This ensures the next bookmarked heading will be placed
+            // at most as deep as its topmost skipped ancestors. Deeper
+            // ancestors do not matter as the nesting structure they create
+            // won't be visible in the PDF outline.
+            last_skipped_level = Some(leaf.level);
+        }
+    }
+
+    (!tree.is_empty()).then_some(tree)
+}
+
+impl HeadingNode {
+    fn leaf(introspector: &mut Introspector, element: Content) -> Self {
+        let position = {
+            let loc = element.location().unwrap();
+            introspector.position(loc)
+        };
+
+        HeadingNode {
+            level: element.expect_field::<NonZeroUsize>("level"),
+            position,
+            // 'bookmarked' set to 'auto' falls back to the value of 'outlined'.
+            bookmarked: element
+                .expect_field::<Smart<bool>>("bookmarked")
+                .unwrap_or_else(|| element.expect_field::<bool>("outlined")),
+            element,
+            children: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Outline {
+    items: Vec<OutlineItem>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct OutlineItem {
+    title: String,
+    position: Option<CursorPosition>,
+    children: Vec<OutlineItem>,
+}
+
+pub fn outline(document: &TypstDocument) -> Outline {
+    let mut introspector = Introspector::new(&document.pages);
+    let outline = crate::actor::outline::get_outline(&mut introspector);
+    let mut items = Vec::with_capacity(outline.as_ref().map_or(0, Vec::len));
+
+    for heading in outline.iter().flatten() {
+        outline_item(heading, &mut items);
+    }
+
+    Outline { items }
+}
+
+fn outline_item(src: &HeadingNode, res: &mut Vec<OutlineItem>) {
+    let body = src.element.expect_field::<Content>("body");
+    let title = body.plain_text().trim().to_owned();
+
+    let position = Some(CursorPosition {
+        page_no: src.position.page.into(),
+        x: src.position.point.x.to_pt(),
+        y: src.position.point.y.to_pt(),
+    });
+
+    let mut children = Vec::with_capacity(src.children.len());
+    for child in src.children.iter() {
+        outline_item(child, &mut children);
+    }
+
+    res.push(OutlineItem {
+        title,
+        position,
+        children,
+    });
+}


### PR DESCRIPTION
![image](https://github.com/Enter-tainer/typst-preview/assets/35292584/02b64449-dd34-4a5e-89b5-afc36631d1bd)

Todo: 
+ [x] Add an option to disable this feature
+ [ ] optional: change rendering mode to `canvas`
