### PR TITLE
fix: increase height of the SVG container before scrolling down

### DIFF
--- a/addons/frontend/src/svg-doc.ts
+++ b/addons/frontend/src/svg-doc.ts
@@ -113,6 +113,9 @@ export class SvgDocument {
       if (event.ctrlKey) {
         event.preventDefault();
 
+        // retrieve dom state before any operation
+        this.cachedDOMState = this.retrieveDOMState();
+
         if (window.onresize !== null) {
           // is auto resizing
           window.onresize = null;
@@ -162,6 +165,9 @@ export class SvgDocument {
 
           const dataHeight = Number.parseFloat(svg.getAttribute("data-height")!);
           const scaledHeight = Math.ceil(dataHeight * scaleRatio);
+
+          // we increase the height by 2 times.
+          // The `2` is only a magic number that is large enough.
           this.hookedElem.style.height = `${scaledHeight * 2}px`;
         }
 

--- a/addons/frontend/src/svg-doc.ts
+++ b/addons/frontend/src/svg-doc.ts
@@ -155,6 +155,16 @@ export class SvgDocument {
           document.body.classList.remove("hide-scrollbar-x");
         }
 
+        // reserve space to scroll down
+        const svg = this.hookedElem.firstElementChild! as SVGElement;
+        if (svg) {
+          const scaleRatio = this.getSvgScaleRatio();
+
+          const dataHeight = Number.parseFloat(svg.getAttribute("data-height")!);
+          const scaledHeight = Math.ceil(dataHeight * scaleRatio);
+          this.hookedElem.style.height = `${scaledHeight * 2}px`;
+        }
+
         // make sure the cursor is still on the same position
         window.scrollBy(scrollX, scrollY);
         // toggle scale change event
@@ -176,21 +186,34 @@ export class SvgDocument {
     }
   }
 
-  // Note: one should retrieve dom state before rescale
-  rescale() {
+  /// Get current scale from html to svg
+  getSvgScaleRatio() {
+    const svg = this.hookedElem.firstElementChild as SVGElement;
+    if (!svg) {
+      return 0;
+    }
+
     // get dom state from cache, so we are free from layout reflowing
     // Note: one should retrieve dom state before rescale
     const { width: containerWidth } = this.cachedDOMState;
-    const svg = this.hookedElem.firstElementChild! as SVGElement;
-
     this.currentContainerWidth = containerWidth;
     const svgWidth = Number.parseFloat(
       svg.getAttribute("data-width") || svg.getAttribute("width") || "1"
     );
     this.currentRealScale = this.currentContainerWidth / svgWidth;
-    this.currentContainerWidth = containerWidth;
 
-    const scale = this.currentRealScale * this.currentScaleRatio;
+    return this.currentRealScale * this.currentScaleRatio;
+  }
+
+  // Note: one should retrieve dom state before rescale
+  rescale() {
+    const svg = this.hookedElem.firstElementChild! as SVGElement;
+
+    const scale = this.getSvgScaleRatio();
+    if (scale === 0) {
+      console.warn("determine scale as 0, skip rescale");
+      return;
+    }
 
     // apply scale
     const dataWidth = Number.parseFloat(svg.getAttribute("data-width")!);
@@ -209,6 +232,9 @@ export class SvgDocument {
       svg.setAttribute("data-applied-height", appliedHeight);
       svg.setAttribute("height", `${scaledHeight}`);
     }
+
+    // change height of the container back from `installCtrlWheelHandler` hack
+    this.hookedElem.style.height = `${scaledHeight}px`;
   }
 
   private decorateSvgElement(svg: SVGElement) {


### PR DESCRIPTION
fix #128.

Description: when somebody tries to zoom out, we has a wrong order of steps to go:

+ Initially, the viewport is at `(10000px, 0px)`, and the div element has a height of `10000px`.
+ To adjust position, js requests viewport to scroll down by `2500px`, however it hits the bottom of the div element, so it doesn't scroll down by `2500px` as expected.
+ change height of a div element to a larger value, e.g. from `10000px` to `12500px`.

Finally, the viewport is kept at the position `(10000px, 0px)` but the div element is resized to `12500px`.

If we reserve a larger height before scrolling, the wrong order steps doesn't bother.