### PR TITLE
fix: sticky scrolling

### DIFF
--- a/addons/frontend/src/svg-doc.ts
+++ b/addons/frontend/src/svg-doc.ts
@@ -240,7 +240,9 @@ export class SvgDocument {
     }
 
     // change height of the container back from `installCtrlWheelHandler` hack
-    this.hookedElem.style.height = `${scaledHeight}px`;
+    if (this.hookedElem.style.height) {
+      this.hookedElem.style.removeProperty("height");
+    }
   }
 
   private decorateSvgElement(svg: SVGElement) {


### PR DESCRIPTION
fix #185,  that holds a "height" attribute constantly would introduce weird sticky behavior on browser handling scrolling content.