### PR TITLE
Add keybinding `ctrl+k v` to the extension

### DIFF
--- a/addons/vscode/README.md
+++ b/addons/vscode/README.md
@@ -10,6 +10,8 @@ Preview your Typst files in vscode instantly!
 
 Install this extension from [marketplace](https://marketplace.visualstudio.com/items?itemName=mgt19937.typst-preview), open command palette (Ctrl+Shift+P), and type `>Typst Preview:`.
 
+You can also use the shortcut (Ctrl+K V).
+
 ![demo](demo.png)
 
 https://github.com/Enter-tainer/typst-preview/assets/25521218/600529ce-8f42-4c2f-a224-b6b73e6ad017

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -157,7 +157,15 @@
           ]
         }
       }
-    }
+    },
+    "keybindings": [
+      {
+        "command": "typst-preview.preview",
+        "key": "ctrl+k v",
+        "mac": "cmd+k v",
+        "when": "editorLangId == typst"
+      }
+    ]
   },
   "scripts": {
     "build:frontend": "cd ../frontend && yarn run build && cd ../vscode && rimraf ./out/frontend/ && cpr ../frontend/dist/ ./out/frontend/",


### PR DESCRIPTION
`ctrl+k v` is the default keybinding for "Open Markdown preview" in [vscode](https://code.visualstudio.com/shortcuts/keyboard-shortcuts-windows.pdf) and [markdown preview enhanced extension](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/blob/develop/package.json).

I think typst preview should also bind this shortcut to typst files, which is more convenient and can prevent some users from still using pdf preview.

<img width="100px" src="https://github.com/Enter-tainer/typst-preview/assets/34951714/6f95bbe4-8c24-468a-9806-3e6170ccbbba" />

