### PR TITLE
dev: employ a new algorithm to handle typst location

### DIFF
--- a/addons/frontend/src/svg-animation.ts
+++ b/addons/frontend/src/svg-animation.ts
@@ -3,13 +3,18 @@ export function triggerRipple(
   left: number,
   top: number,
   className: string,
-  animation: string
+  animation: string,
+  color?: string,
 ) {
   const ripple = document.createElement("div");
 
   ripple.className = className;
   ripple.style.left = left.toString() + "px";
   ripple.style.top = top.toString() + "px";
+
+  if (color) {
+    ripple.style.border = `1px solid ${color}`;
+  }
 
   docRoot.appendChild(ripple);
 


### PR DESCRIPTION
The code positions the preview panel at the top (38.2%) left (7%) of the viewport. It then detects which half of the page the user is previewing if some zoom-in scale is applied - left or right side. The preview panel's x coordinate is snapped to align with either the left or right edge of the visible page section, to ensure a suitable position.

The code only takes the single-column and 2-column layout into consideration, which has space to improvement.

1. See the picture, there are three length retrieved from DOM:
    1. `1ph` is 1% height of the viewport.
    2. `1pgw` is 1% width of the focused page. 
    3. `1pw` is 1% width of the viewport.
2. calculate the position of the typst location as `p = (x, y)`.
3. If `viewport.width >= 90pgw || viewport.width < 50pgw`,
    1. scroll to `(x - 7pw, y - 38.2ph)`.
3. otherwise, `viewport.width >= 50pgw && viewport.width < 90pgw`,
    See blue lines in the picture as the example.
    1. if `p` is in the left side of page (`x < 50pgw`), scroll to `(-5pw, y - 38.2ph)`;
    1. if `p` is in the right side of page (`x >= 50pgw`), scroll to `(50pgw - 5pw, y - 38.2ph)`.

![image](https://github.com/Enter-tainer/typst-preview/assets/35292584/800f3236-c06b-4568-be5e-b9cb1c80b399)
