### PR TITLE
feat: click outline and jump to relevant source/frame position

### DIFF
--- a/addons/frontend/src/ws.ts
+++ b/addons/frontend/src/ws.ts
@@ -269,12 +269,21 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
             ];
             // console.log(message[0], message[1].length);
             if (isContentPreview) {
-                if ((message[0] === "jump" || message[0] === "partial-rendering" || message[0] === "cursor")) {
+                // whether to scroll to the content preview when user updates document
+                const autoScrollContentPreview = false;
+                if (!autoScrollContentPreview && message[0] === "jump") {
+                    return;
+                }
+
+                // "viewport": viewport change to document doesn't affect content preview
+                // "partial-rendering": content previe always render partially
+                // "cursor": currently not supported
+                if ((message[0] === "viewport" || message[0] === "partial-rendering" || message[0] === "cursor")) {
                     return;
                 }
             }
 
-            if (message[0] === "jump") {
+            if (message[0] === "jump" || message[0] === "viewport") {
                 // todo: aware height padding
                 const [page, x, y] = dec
                     .decode((message[1] as any).buffer)

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -77,6 +77,13 @@
         "description": "Show typst-preview log",
         "icon": "$(list-flat)",
         "when": "resourceLangId == typst"
+      },
+      {
+        "command": "typst-preview.revealDocument",
+        "title": "Typst Preview: Reveal document by span or physical document position",
+        "description": "Reveal document by span or physical document position, internally used by typst-preview",
+        "icon": "$(open-preview)",
+        "when": "resourceLangId == typst"
       }
     ],
     "menus": {

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -135,6 +135,25 @@ function getProjectRoot(currentPath: string): string {
 const serverProcesses: Array<any> = [];
 const activeTask = new Map<vscode.TextDocument, TaskControlBlock>();
 
+interface SourceScrollBySpanRequest {
+	event: 'sourceScrollBySpan';
+	span: string;
+}
+
+interface ScrollByPositionRequest {
+	event: 'panelScrollByPosition' | 'sourceScrollByPosition';
+	position: any;
+}
+
+interface ScrollRequest {
+	event: string;
+	filepath: string;
+	line: any;
+	character: any;
+}
+
+type DocRequests = SourceScrollBySpanRequest | ScrollByPositionRequest | ScrollRequest;
+
 // If there is only one preview task, we treat the workspace as a multi-file project,
 // so `Sync preview with cursor` command in any file goes to the unique preview server.
 //
@@ -144,8 +163,8 @@ const activeTask = new Map<vscode.TextDocument, TaskControlBlock>();
 // This is a compromise we made to support multi-file projects after evaluating performance,
 // effectiveness, and user needs.
 // See https://github.com/Enter-tainer/typst-preview/issues/164 for more detail.
-const reportPosition = async (bindDocument: vscode.TextDocument, activeEditor: vscode.TextEditor, event: string) => {
-	let tcb = activeTask.get(bindDocument);
+const sendDocRequest = async (bindDocument: vscode.TextDocument | undefined, scrollRequest: DocRequests) => {
+	let tcb = bindDocument && activeTask.get(bindDocument);
 	if (tcb === undefined) {
 		if (activeTask.size === 1) {
 			tcb = Array.from(activeTask.values())[0];
@@ -153,15 +172,18 @@ const reportPosition = async (bindDocument: vscode.TextDocument, activeEditor: v
 			return;
 		}
 	}
-	const { addonΠserver } = tcb;
-	const scrollRequest = {
+	tcb.addonΠserver.send(JSON.stringify(scrollRequest));
+};
+
+const reportPosition = async (bindDocument: vscode.TextDocument, activeEditor: vscode.TextEditor, event: string) => {
+	const scrollRequest: ScrollRequest = {
 		event,
 		'filepath': bindDocument.uri.fsPath,
 		'line': activeEditor.selection.active.line,
 		'character': activeEditor.selection.active.character,
 	};
-	console.log(scrollRequest);
-	addonΠserver.send(JSON.stringify(scrollRequest));
+	// console.log(scrollRequest);
+	sendDocRequest(bindDocument, scrollRequest);
 };
 
 interface TaskControlBlock {
@@ -655,7 +677,11 @@ export class OutlineItem extends vscode.TreeItem {
 	constructor(
 		public readonly data: OutlineItemData,
 		public readonly collapsibleState: vscode.TreeItemCollapsibleState,
-		public readonly command?: vscode.Command
+		public readonly command: vscode.Command = {
+			title: 'Reveal Outline Item',
+			command: 'typst-preview.revealDocument',
+			arguments: [{ span: data.span, position: data.position }],
+		}
 	) {
 		super(data.title, collapsibleState);
 		const span = this.data.span;
@@ -723,11 +749,31 @@ export function activate(context: vscode.ExtensionContext) {
 
 		reportPosition(activeEditor.document, activeEditor, 'panelScrollTo');
 	});
+	let revealDocumentDisposable = vscode.commands.registerCommand('typst-preview.revealDocument', async (args) => {
+		console.log(args);
+		// That's very unfortunate that sourceScrollBySpan doesn't work well.
+		// if (args.span) {
+		// 	sendDocRequest(undefined, {
+		// 		event: 'sourceScrollBySpan',
+		// 		span: args.span,
+		// 	});
+		// }
+		if (args.position) { // todo: tagging document
+			sendDocRequest(undefined, {
+				event: 'sourceScrollByPosition',
+				position: args.position,
+			});
+			sendDocRequest(undefined, {
+				event: 'panelScrollByPosition',
+				position: args.position,
+			});
+		}
+	});
 	let showLogDisposable = vscode.commands.registerCommand('typst-preview.showLog', async () => {
 		outputChannel.show();
 	});
 
-	context.subscriptions.push(webviewDisposable, browserDisposable, webviewSlideDisposable, browserSlideDisposable, syncDisposable, showLogDisposable, statusBarItem);
+	context.subscriptions.push(webviewDisposable, browserDisposable, webviewSlideDisposable, browserSlideDisposable, syncDisposable, showLogDisposable, statusBarItem, revealDocumentDisposable);
 	process.on('SIGINT', () => {
 		for (const serverProcess of serverProcesses) {
 			serverProcess.kill();

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -638,7 +638,6 @@ class OutlineProvider implements vscode.TreeDataProvider<OutlineItem> {
 
 	getChildren(element?: OutlineItem): Thenable<OutlineItem[]> {
 		if (!this.outline) {
-			vscode.window.showInformationMessage('No dependency in empty workspace');
 			return Promise.resolve([]);
 		}
 

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -608,6 +608,7 @@ interface CursorPosition {
 
 interface OutlineItemData {
 	title: string,
+	span?: string,
 	position?: CursorPosition,
 	children: OutlineItemData[],
 }
@@ -657,13 +658,15 @@ export class OutlineItem extends vscode.TreeItem {
 		public readonly command?: vscode.Command
 	) {
 		super(data.title, collapsibleState);
+		const span = this.data.span;
+		let detachedHint = span ? `` : `, detached`;
 
 		const pos = this.data.position;
 		if (pos) {
-			this.tooltip = `${this.label} in page ${pos.page_no}, at (${pos.x.toFixed(3)} pt, ${pos.y.toFixed(3)} pt)`;
-			this.description = `page: ${pos.page_no}, at (${pos.x.toFixed(1)} pt, ${pos.y.toFixed(1)} pt)`;
+			this.tooltip = `${this.label} in page ${pos.page_no}, at (${pos.x.toFixed(3)} pt, ${pos.y.toFixed(3)} pt)${detachedHint}`;
+			this.description = `page: ${pos.page_no}, at (${pos.x.toFixed(1)} pt, ${pos.y.toFixed(1)} pt)${detachedHint}`;
 		} else {
-			this.tooltip = `${this.label}`;
+			this.tooltip = `${this.label}${detachedHint}`;
 			this.description = `no pos`;
 		}
 	}

--- a/src/actor/debug_loc.rs
+++ b/src/actor/debug_loc.rs
@@ -1,0 +1,73 @@
+use serde::{Deserialize, Serialize};
+use typst::{doc::Position as TypstPosition, geom::Point};
+
+/// A serializable physical position in a document.
+///
+/// Note that it uses [`f32`] instead of [`f64`] as same as
+/// [`TypstPosition`] for the coordinates to improve both performance
+/// of serialization and calculation. It does sacrifice the floating
+/// precision, but it is enough in our use cases.
+///
+/// Also see [`TypstPosition`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct DocumentPosition {
+    /// The page, starting at 1.
+    pub page_no: usize,
+    /// The exact x-coordinate on the page (from the left, as usual).
+    pub x: f32,
+    /// The exact y-coordinate on the page (from the top, as usual).
+    pub y: f32,
+}
+
+impl DocumentPosition {
+    pub fn point(&self) -> Point {
+        use typst::geom::Abs;
+        Point::new(Abs::raw(self.x as f64), Abs::raw(self.y as f64))
+    }
+}
+
+impl From<TypstPosition> for DocumentPosition {
+    fn from(position: TypstPosition) -> Self {
+        Self {
+            page_no: position.page.into(),
+            x: position.point.x.to_pt() as f32,
+            y: position.point.y.to_pt() as f32,
+        }
+    }
+}
+
+// /// Unevaluated source span.
+// /// The raw source span is unsafe to serialize and deserialize.
+// /// Because the real source location is only known during liveness of
+// /// the compiled document.
+// pub type SourceSpan = typst::syntax::Span;
+
+// /// Raw representation of a source span.
+// pub type RawSourceSpan = u64;
+
+// /// A char position represented in form of line and column.
+// /// The position is encoded in Utf-8 or Utf-16, and the encoding is
+// /// determined by usage.
+// ///
+// pub struct CharPosition {
+//     /// The line number, starting at 0.
+//     line: usize,
+//     /// The column number, starting at 0.
+//     column: usize,
+// }
+
+// /// A resolved source (text) location.
+// ///
+// /// See [`CharPosition`] for the definition of the position inside a file.
+// pub struct SourceLocation {
+//     filepath: PathBuf,
+//     pos: CharPosition,
+// }
+// /// A resolved source (text) range.
+// ///
+// /// See [`CharPosition`] for the definition of the position inside a file.
+// pub struct SourceRange {
+//     filepath: PathBuf,
+//     start: CharPosition,
+//     end: CharPosition,
+// }

--- a/src/actor/editor.rs
+++ b/src/actor/editor.rs
@@ -1,14 +1,31 @@
 use futures::{SinkExt, StreamExt};
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
-use tokio::net::TcpStream;
 use tokio::sync::mpsc;
+use tokio::{net::TcpStream, sync::broadcast};
 use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
 
 use crate::{
     actor::outline::Outline, actor::typst::TypstActorRequest, ChangeCursorPositionRequest,
     DocToSrcJumpInfo, MemoryFiles, MemoryFilesShort, SrcToDocJumpRequest,
 };
+
+use super::{debug_loc::DocumentPosition, webview::WebviewActorRequest};
+#[derive(Debug, Deserialize)]
+pub struct DocToSrcJumpResolveRequest {
+    /// Span id in hex-format.
+    span: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SourceScrollByPositionRequest {
+    position: DocumentPosition,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PanelScrollByPositionRequest {
+    position: DocumentPosition,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "data")]
@@ -30,6 +47,7 @@ pub struct EditorActor {
     editor_websocket_conn: WebSocketStream<TcpStream>,
 
     world_sender: mpsc::UnboundedSender<TypstActorRequest>,
+    webview_sender: broadcast::Sender<WebviewActorRequest>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -39,6 +57,12 @@ enum ControlPlaneMessage {
     ChangeCursorPosition(ChangeCursorPositionRequest),
     #[serde(rename = "panelScrollTo")]
     SrcToDocJump(SrcToDocJumpRequest),
+    #[serde(rename = "panelScrollByPosition")]
+    PanelScrollByPosition(PanelScrollByPositionRequest),
+    #[serde(rename = "sourceScrollByPosition")]
+    SourceScrollByPosition(SourceScrollByPositionRequest),
+    #[serde(rename = "sourceScrollBySpan")]
+    DocToSrcJumpResolve(DocToSrcJumpResolveRequest),
     #[serde(rename = "syncMemoryFiles")]
     SyncMemoryFiles(MemoryFiles),
     #[serde(rename = "updateMemoryFiles")]
@@ -65,11 +89,13 @@ impl EditorActor {
         mailbox: mpsc::UnboundedReceiver<EditorActorRequest>,
         editor_websocket_conn: WebSocketStream<TcpStream>,
         world_sender: mpsc::UnboundedSender<TypstActorRequest>,
+        webview_sender: broadcast::Sender<WebviewActorRequest>,
     ) -> Self {
         Self {
             mailbox,
             editor_websocket_conn,
             world_sender,
+            webview_sender,
         }
     }
 
@@ -119,25 +145,38 @@ impl EditorActor {
                     match msg {
                         ControlPlaneMessage::ChangeCursorPosition(cursor_info) => {
                             debug!("EditorActor: received message from editor: {:?}", cursor_info);
-                            self.world_sender.send(TypstActorRequest::ChangeCursorPosition(cursor_info))
+                            self.world_sender.send(TypstActorRequest::ChangeCursorPosition(cursor_info)).unwrap();
                         }
                         ControlPlaneMessage::SrcToDocJump(jump_info) => {
                             debug!("EditorActor: received message from editor: {:?}", jump_info);
-                            self.world_sender.send(TypstActorRequest::SrcToDocJumpResolve(jump_info))
+                            self.world_sender.send(TypstActorRequest::SrcToDocJumpResolve(jump_info)).unwrap();
+                        }
+                        ControlPlaneMessage::SourceScrollByPosition(jump_info) => {
+                            debug!("EditorActor: received message from editor: {:?}", jump_info);
+                            self.world_sender.send(TypstActorRequest::JumpToSrcByPosition(jump_info.position)).unwrap();
+                        }
+                        ControlPlaneMessage::PanelScrollByPosition(jump_info) => {
+                            debug!("EditorActor: received message from editor: {:?}", jump_info);
+                            self.webview_sender.send(WebviewActorRequest::ViewportPosition(jump_info.position)).unwrap();
+                        }
+                        ControlPlaneMessage::DocToSrcJumpResolve(jump_info) => {
+                            debug!("EditorActor: received message from editor: {:?}", jump_info);
+                            let jump_info = u64::from_str_radix(&jump_info.span, 16).unwrap();
+                            self.world_sender.send(TypstActorRequest::DocToSrcJumpResolve(jump_info)).unwrap();
                         }
                         ControlPlaneMessage::SyncMemoryFiles(memory_files) => {
                             debug!("EditorActor: received message from editor: SyncMemoryFiles {:?}", memory_files.files.keys().collect::<Vec<_>>());
-                            self.world_sender.send(TypstActorRequest::SyncMemoryFiles(memory_files))
+                            self.world_sender.send(TypstActorRequest::SyncMemoryFiles(memory_files)).unwrap();
                         }
                         ControlPlaneMessage::UpdateMemoryFiles(memory_files) => {
                             debug!("EditorActor: received message from editor: UpdateMemoryFiles {:?}", memory_files.files.keys().collect::<Vec<_>>());
-                            self.world_sender.send(TypstActorRequest::UpdateMemoryFiles(memory_files))
+                            self.world_sender.send(TypstActorRequest::UpdateMemoryFiles(memory_files)).unwrap();
                         }
                         ControlPlaneMessage::RemoveMemoryFiles(memory_files) => {
                             debug!("EditorActor: received message from editor: RemoveMemoryFiles {:?}", &memory_files.files);
-                            self.world_sender.send(TypstActorRequest::RemoveMemoryFiles(memory_files))
+                            self.world_sender.send(TypstActorRequest::RemoveMemoryFiles(memory_files)).unwrap();
                         }
-                    }.unwrap();
+                    };
                 }
             }
         }

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -1,3 +1,4 @@
+pub mod debug_loc;
 pub mod editor;
 mod outline;
 pub mod render;

--- a/src/actor/outline.rs
+++ b/src/actor/outline.rs
@@ -7,7 +7,7 @@ use typst::{
 };
 use typst_ts_core::TypstDocument;
 
-use super::webview::CursorPosition;
+use super::debug_loc::DocumentPosition;
 
 /// A heading in the outline panel.
 #[derive(Debug, Clone)]
@@ -122,7 +122,7 @@ pub struct Outline {
 #[derive(Debug, Clone, serde::Serialize)]
 struct OutlineItem {
     title: String,
-    position: Option<CursorPosition>,
+    position: Option<DocumentPosition>,
     children: Vec<OutlineItem>,
 }
 
@@ -142,11 +142,7 @@ fn outline_item(src: &HeadingNode, res: &mut Vec<OutlineItem>) {
     let body = src.element.expect_field::<Content>("body");
     let title = body.plain_text().trim().to_owned();
 
-    let position = Some(CursorPosition {
-        page_no: src.position.page.into(),
-        x: src.position.point.x.to_pt(),
-        y: src.position.point.y.to_pt(),
-    });
+    let position = Some(src.position.into());
 
     let mut children = Vec::with_capacity(src.children.len());
     for child in src.children.iter() {

--- a/src/actor/typst.rs
+++ b/src/actor/typst.rs
@@ -206,17 +206,12 @@ impl TypstClient {
                         error!("TypstActor: failed to resolve cursor position: {:#}", err);
                     })
                     .ok()
-                    .flatten()
-                    .map(|jump_pos| SrcToDocJumpInfo {
-                        page_no: jump_pos.page.into(),
-                        x: jump_pos.point.x.to_pt(),
-                        y: jump_pos.point.y.to_pt(),
-                    });
+                    .flatten();
 
                 if let Some(info) = res {
                     let _ = self
                         .webview_conn_sender
-                        .send(WebviewActorRequest::CursorPosition(info));
+                        .send(WebviewActorRequest::CursorPosition(info.into()));
                 }
             }
             TypstActorRequest::SrcToDocJumpResolve(req) => {
@@ -230,17 +225,12 @@ impl TypstClient {
                         error!("TypstActor: failed to resolve src to doc jump: {:#}", err);
                     })
                     .ok()
-                    .flatten()
-                    .map(|jump_pos| SrcToDocJumpInfo {
-                        page_no: jump_pos.page.into(),
-                        x: jump_pos.point.x.to_pt(),
-                        y: jump_pos.point.y.to_pt(),
-                    });
+                    .flatten();
 
                 if let Some(info) = res {
                     let _ = self
                         .webview_conn_sender
-                        .send(WebviewActorRequest::SrcToDocJump(info));
+                        .send(WebviewActorRequest::SrcToDocJump(info.into()));
                 }
             }
             TypstActorRequest::SyncMemoryFiles(m) => {

--- a/src/actor/typst.rs
+++ b/src/actor/typst.rs
@@ -200,6 +200,8 @@ impl TypstClient {
                         find_in_frame(frame, pos.point(), &filter_by_main)
                             .or_else(|| {
                                 // unfortunately, the heading element is not in the main file
+                                // See <https://github.com/Enter-tainer/typst-preview/pull/193> for
+                                // algorithmic description.
 
                                 // find all locations in the frame and in the main file
                                 let mut locations = vec![];

--- a/src/actor/typst.rs
+++ b/src/actor/typst.rs
@@ -228,17 +228,16 @@ impl TypstClient {
 
                                 // calculate reasonable delta bound
                                 let average_delta =
-                                    lines.windows(2).map(|w| w[1] - w[0]).sum::<usize>()
-                                        / lines.len();
+                                    lines.windows(2).map(|w| (w[1] - w[0]) as f32).sum::<f32>()
+                                        / lines.len() as f32;
                                 let average_sigma = (lines
                                     .windows(2)
-                                    .map(|w| (w[1] - w[0] - average_delta).pow(2) as f32)
+                                    .map(|w| ((w[1] - w[0]) as f32 - average_delta).powf(2.))
                                     .sum::<f32>()
                                     / lines.len() as f32)
-                                    .sqrt()
-                                    .ceil()
-                                    as usize;
-                                let reasonable_delta_bound = average_delta + average_sigma * 2;
+                                    .sqrt();
+                                let reasonable_delta_bound =
+                                    (average_delta + average_sigma * 2.).ceil() as usize;
 
                                 // pick the last contiguous lines
                                 let mut pick_line = lines.last().cloned().unwrap_or_default();

--- a/src/actor/webview.rs
+++ b/src/actor/webview.rs
@@ -6,16 +6,13 @@ use tokio::{
 };
 use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
 
-use super::{outline::Outline, render::RenderActorRequest, typst::TypstActorRequest};
+use super::{
+    debug_loc::DocumentPosition, outline::Outline, render::RenderActorRequest,
+    typst::TypstActorRequest,
+};
 
-#[derive(Debug, Clone, Copy, serde::Serialize)]
-pub struct CursorPosition {
-    pub page_no: usize,
-    pub x: f64,
-    pub y: f64,
-}
-
-pub type SrcToDocJumpInfo = CursorPosition;
+pub type CursorPosition = DocumentPosition;
+pub type SrcToDocJumpInfo = DocumentPosition;
 
 #[derive(Debug, Clone)]
 pub enum WebviewActorRequest {
@@ -23,11 +20,11 @@ pub enum WebviewActorRequest {
     CursorPosition(CursorPosition),
 }
 
-fn src_to_doc_jump_to_string(page_no: usize, x: f64, y: f64) -> String {
+fn src_to_doc_jump_to_string(page_no: usize, x: f32, y: f32) -> String {
     format!("jump,{page_no} {x} {y}")
 }
 
-fn cursor_position_to_string(page_no: usize, x: f64, y: f64) -> String {
+fn cursor_position_to_string(page_no: usize, x: f32, y: f32) -> String {
     format!("cursor,{page_no} {x} {y}")
 }
 


### PR DESCRIPTION
Click outline and jump to relevant source/frame position.

The outline jump can retrieve a span and a frame position from the heading (outline) element, but we cannot simply use the span since it may (sometime almost) dive into the package files. Hence the outline jump starts from find a suitable span in the frame by position.

Let's consider a algorithm to find a such span by position.
First, if there is a spanned frame item hit by the position, we use the frame item.
Otherwise, we perform a fuzzy search. Before search we've collected all line numbers $L = l_i$ and byte offset $o_i$ of the spanned frame item.
1. locate the first clustered line number $l = \min S$, where recusively $`S = \left\{ l_n \right\} \cup \left\{ l_i| \mid l_i - \min S|
 \leqslant \Delta\right\}`$, and $\Delta = \overline{\delta_L} + 2 \sigma(\delta_L)$.
2. find the span having the minimum $o_i$ at the line $l$
