### PR TITLE
feat: render dummy "SVG page"s as canvas pictures

### DIFF
--- a/addons/frontend/package.json
+++ b/addons/frontend/package.json
@@ -12,8 +12,8 @@
     "link:local": "yarn link @myriaddreamin/typst.ts @myriaddreamin/typst-ts-renderer"
   },
   "dependencies": {
-    "@myriaddreamin/typst-ts-renderer": "0.4.1",
-    "@myriaddreamin/typst.ts": "0.4.1",
+    "@myriaddreamin/typst-ts-renderer": "0.4.2-rc1",
+    "@myriaddreamin/typst.ts": "0.4.2-rc1",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {

--- a/addons/frontend/src/typst-doc.ts
+++ b/addons/frontend/src/typst-doc.ts
@@ -28,6 +28,14 @@ export enum PreviewMode {
 
 // let rnd = 0;
 
+function isEmptyPage(elem: Element): boolean {
+  return elem.getAttribute(TypstPatchAttrs.Tid) == 'pqKorb/btZUQlH2NwQkOiBc'
+}
+
+function isReusingEmptyPage(elem: Element): boolean {
+  return elem.getAttribute(TypstPatchAttrs.ReuseFrom) == 'pqKorb/btZUQlH2NwQkOiBc'
+}
+
 class TypstDocumentImpl {
   /// Configuration fields
 
@@ -58,6 +66,8 @@ class TypstDocumentImpl {
   patchQueue: [string, string][] = [];
   /// resources to dispose
   private disposeList: (() => void)[] = [];
+  /// canvas render ctoken
+  canvasRenderCToken?: TypstCancellationToken;
 
   /// There are two scales in this class: The real scale is to adjust the size
   /// of `hookedElem` to fit the svg. The virtual scale (scale ratio) is to let
@@ -439,7 +449,14 @@ class TypstDocumentImpl {
     /// Caclulate width
     let maxWidth = 0;
 
-    const nextPages = (() => {
+    interface SvgPage {
+      elem: Element;
+      width: number;
+      height: number;
+      index: number;
+    }
+
+    const nextPages: SvgPage[] = (() => {
       /// Retrieve original pages
       const filteredNextPages = Array.from(svg.children).filter(
         (x) => x.classList.contains("typst-page")
@@ -454,11 +471,12 @@ class TypstDocumentImpl {
       } else {
         throw new Error(`unknown preview mode ${mode}`);
       }
-    })().map((elem) => {
+    })().map((elem, index) => {
       const width = Number.parseFloat(elem.getAttribute("data-page-width")!);
       const height = Number.parseFloat(elem.getAttribute("data-page-height")!);
       maxWidth = Math.max(maxWidth, width);
       return {
+        index,
         elem,
         width,
         height,
@@ -492,10 +510,50 @@ class TypstDocumentImpl {
     const firstPage = (nextPages.length ? nextPages[0] : undefined)!;
     let firstRect: SVGRectElement = undefined!;
 
+    const pagesInCanvasMode: CanvasPage[] = [];
+    /// Number to canvas page mapping
+    const n2CMapping = new Map<number, CanvasPage>();
+    const createCanvasPageOn = (nextPage: SvgPage) => {
+      const { elem, width, height, index } = nextPage;
+      const pg: CanvasPage = {
+        tag: 'canvas', index, width, height, container: undefined!, elem: undefined!,
+        inserter: (pageInfo) => {
+          const foreignObject = document.createElementNS("http://www.w3.org/2000/svg", "foreignObject");
+          elem.appendChild(foreignObject);
+          foreignObject.setAttribute('width', `${width}`);
+          foreignObject.setAttribute('height', `${height}`);
+          foreignObject.classList.add('typst-svg-mixin-canvas');
+          foreignObject.prepend(pageInfo.container);
+        }
+      };
+      n2CMapping.set(index, pg);
+      pagesInCanvasMode.push(pg);
+    }
+
     for (let i = 0; i < nextPages.length; i++) {
       /// Retrieve page width, height
       const nextPage = nextPages[i];
       const { width: pageWidth, height: pageHeight } = nextPage;
+
+      /// Switch a dummy svg page to canvas mode
+      const nextElem = nextPage.elem;
+      if (isEmptyPage(nextElem)) {
+        /// Render this page as canvas
+        createCanvasPageOn(nextPage);
+        nextElem.setAttribute('data-mixin-canvas', '1');
+
+        /// override reuse info for virtual DOM patching
+        ///
+        /// we cannot have much work to do, but we optimistically think of the canvas
+        /// on the same page offset are the same canvas element.
+        const offsetTag = `canvas:${nextPage.index}`;
+        nextElem.setAttribute(TypstPatchAttrs.Tid, offsetTag);
+        nextElem.setAttribute(TypstPatchAttrs.ReuseFrom, offsetTag);
+      }
+      if (isReusingEmptyPage(nextElem)) {
+        /// delete reuse from empty page
+        nextElem.removeAttribute(TypstPatchAttrs.ReuseFrom);
+      }
 
       /// center the page and add margin
       const calculatedPaddedX = (newWidth - pageWidth) / 2;
@@ -563,6 +621,36 @@ class TypstDocumentImpl {
 
       accumulatedHeight = calculatedPaddedY + pageHeightEnd;
     }
+
+    /// Retrieve original pages
+    for (const prev of this.hookedElem.firstElementChild?.children || []) {
+      if (!prev.classList.contains("typst-page")) {
+        continue;
+      }
+      // nextPage.elem.setAttribute('data-mixin-canvas', 'true');
+      if (prev.getAttribute('data-mixin-canvas') !== '1') {
+        continue;
+      }
+
+      const ch = prev.querySelector('.typst-svg-mixin-canvas');
+      if (ch?.tagName === 'foreignObject') {
+        const canvasDiv = ch.firstElementChild as HTMLDivElement;
+
+        const pageNumber = Number.parseInt(canvasDiv.getAttribute('data-page-number')!);
+        const pageInfo = n2CMapping.get(pageNumber);
+        if (pageInfo) {
+          pageInfo.container = canvasDiv as HTMLDivElement;
+          pageInfo.elem = canvasDiv.firstElementChild as HTMLDivElement;
+        }
+      }
+    }
+
+    this.ensureCreatedCanvas(pagesInCanvasMode);
+    this.canvasRenderCToken = new TypstCancellationToken();
+    this.updateCanvas(pagesInCanvasMode, this.canvasRenderCToken)
+      .then(() => {
+        this.canvasRenderCToken = undefined;
+      });
 
     if (this.isContentPreview) {
       accumulatedHeight += fontSize; // always add a bottom margin for last page number
@@ -693,7 +781,31 @@ class TypstDocumentImpl {
       }
     }
 
-    for (const pageInfo of pagesInfo) {
+    this.ensureCreatedCanvas(pagesInfo, (page) => {
+      if (page.index === 0) {
+        docDiv.prepend(page.container);
+      } else {
+        pagesInfo[page.index - 1].container.after(page.container)
+      }
+    });
+
+    const t2 = performance.now();
+
+    if (docDiv.getAttribute('data-rendering') === 'true') {
+      throw new Error('rendering in progress, possibly a race condition');
+    }
+    docDiv.setAttribute('data-rendering', 'true');
+    await this.updateCanvas(pagesInfo);
+    docDiv.removeAttribute('data-rendering');
+    // }));
+
+    const t3 = performance.now();
+
+    return [t2, t3];
+  }
+
+  ensureCreatedCanvas(pages: CanvasPage[], defaultInserter?: (page: CanvasPage) => void) {
+    for (const pageInfo of pages) {
       if (!pageInfo.elem) {
         pageInfo.elem = document.createElement('div');
         pageInfo.elem.setAttribute('class', 'typst-page-canvas');
@@ -732,27 +844,35 @@ class TypstDocumentImpl {
       if (!pageInfo.container.parentElement) {
         if (pageInfo.inserter) {
           pageInfo.inserter(pageInfo);
+        } else if (defaultInserter) {
+          defaultInserter(pageInfo);
         } else {
-          if (pageInfo.index === 0) {
-            docDiv.prepend(pageInfo.container);
-          } else {
-            pagesInfo[pageInfo.index - 1].container.after(pageInfo.container)
-          }
+          throw new Error('pageInfo.inserter is not defined');
         }
       }
     }
+  }
 
-    const t2 = performance.now();
-
+  private async updateCanvas(pagesInfo: CanvasPage[], tok?: TypstCancellationToken) {
+    const perf = performance.now();
+    console.log('updateCanvas start');
     // todo: priority in window
     // await Promise.all(pagesInfo.map(async (pageInfo) => {
     this.kModule.backgroundColor = '#ffffff';
     this.kModule.pixelPerPt = this.pixelPerPt;
-    if (docDiv.getAttribute('data-rendering') === 'true') {
-      throw new Error('rendering in progress, possibly a race condition');
+    const timeout = async (ms: number) => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(undefined);
+        }, ms);
+      });
     }
-    docDiv.setAttribute('data-rendering', 'true');
     for (const pageInfo of pagesInfo) {
+      if (tok?.isCancelRequested()) {
+        await tok.consume();
+        return;
+      }
+
       const canvas = pageInfo.elem.firstElementChild as HTMLCanvasElement;
       // const tt1 = performance.now();
 
@@ -785,6 +905,7 @@ class TypstDocumentImpl {
         }
       });
       if (cacheKey !== result.cacheKey) {
+        console.log('updateCanvas one miss', cacheKey, result.cacheKey);
         // console.log('renderCanvas', pageInfo.index, performance.now() - tt1, result);
         // todo: cache key changed
         // canvas.width = pageInfo.width * this.pixelPerPt;
@@ -794,14 +915,12 @@ class TypstDocumentImpl {
         canvas.setAttribute('data-cache-key', result.cacheKey);
         pageInfo.elem.setAttribute('data-cache-key', result.cacheKey);
       }
+
+      await timeout(0);
     }
-    docDiv.removeAttribute('data-rendering');
 
-    // }));
-
-    const t3 = performance.now();
-
-    return [t2, t3];
+    console.log('updateCanvas done', performance.now() - perf);
+    await tok?.consume();
   }
 
   private toggleSvgViewportChange() {
@@ -880,8 +999,8 @@ class TypstDocumentImpl {
 
       /// Adjust top and bottom
       const ch = this.hookedElem.firstElementChild?.children;
-      let topEstimate = top - height - 1,
-        bottomEstimate = top + height * 2 + 1;
+      let topEstimate = top - 1,
+        bottomEstimate = top + height + 1;
       if (ch) {
         const pages = Array.from(ch).filter(x => x.classList.contains('typst-page'));
         let minTop = 1e33,
@@ -928,6 +1047,13 @@ class TypstDocumentImpl {
   }
 
   private async processQueue(svgUpdateEvent: [string, string]) {
+    const ctoken = this.canvasRenderCToken;
+    if (ctoken) {
+      await ctoken.cancel();
+      await ctoken.wait();
+      this.canvasRenderCToken = undefined;
+      console.log('cancel canvas rendering');
+    }
     let t0 = performance.now();
     let t1 = undefined;
     let t2 = undefined;
@@ -1129,5 +1255,45 @@ export class TypstDocument {
   setOutineData(outline: any) {
     this.impl.outline = outline;
     this.addViewportChange();
+  }
+}
+
+class TypstCancellationToken {
+  isCancellationRequested: boolean = false;
+  private _onCancelled: Promise<void>;
+  private _onCancelledResolveResolved: Promise<() => void>;
+
+  constructor() {
+    let resolveT: () => void = undefined!;
+    let resolveX: (_: () => void) => void = undefined!;
+    this._onCancelled = new Promise((resolve) => {
+      resolveT = resolve;
+      if (resolveX) {
+        resolveX(resolve);
+      }
+    });
+    this._onCancelledResolveResolved = new Promise((resolve) => {
+      resolveX = resolve;
+      if (resolveT) {
+        resolve(resolveT);
+      }
+    });
+  }
+
+  async cancel(): Promise<void> {
+    await this._onCancelledResolveResolved;
+    this.isCancellationRequested = true;
+  }
+
+  isCancelRequested(): boolean {
+    return this.isCancellationRequested;
+  }
+
+  async consume(): Promise<void> {
+    (await this._onCancelledResolveResolved)();
+  }
+
+  wait(): Promise<void> {
+    return this._onCancelled;
   }
 }

--- a/addons/frontend/src/typst-doc.ts
+++ b/addons/frontend/src/typst-doc.ts
@@ -647,10 +647,13 @@ class TypstDocumentImpl {
       }
 
       this.ensureCreatedCanvas(pagesInCanvasMode);
-      this.canvasRenderCToken = new TypstCancellationToken();
-      this.updateCanvas(pagesInCanvasMode, this.canvasRenderCToken)
-        .then(() => {
-          this.canvasRenderCToken = undefined;
+      console.assert(this.canvasRenderCToken === undefined, 'Noo!!: canvasRenderCToken should be undefined');
+      const tok = this.canvasRenderCToken = new TypstCancellationToken();
+      this.updateCanvas(pagesInCanvasMode, tok)
+        .finally(() => {
+          if (tok === this.canvasRenderCToken) {
+            this.canvasRenderCToken = undefined;
+          }
         });
     }
 

--- a/addons/frontend/src/typst-patch.ts
+++ b/addons/frontend/src/typst-patch.ts
@@ -21,11 +21,18 @@ export const enum TypstPatchAttrs {
   /// The data-bad-equality attribute is used to indicate that the element
   /// doesn't have a good equality on hash.
   BadEquality = "data-bad-equality",
+
+  /// The data-dummy hints that this page is a dummy page (placeholder for a real page).
+  Dummy = "data-dummy",
 }
 
 /// Predicate that a xml element is a `<g>` element.
 function isGElem(node: Element): node is SVGGElement {
   return node.tagName === "g";
+}
+
+export function isDummyPatchElem(elem: Element) {
+  return elem.getAttribute(TypstPatchAttrs.Dummy) === "1";
 }
 
 /// Compare two elements by their data-tid attribute.

--- a/addons/frontend/src/typst-patch.ts
+++ b/addons/frontend/src/typst-patch.ts
@@ -129,12 +129,8 @@ export function interpretTargetView<T extends ElementChildren, U extends T = T>(
       continue;
     }
     if (!availableOwnedResource.has(reuseTargetTid)) {
-      if (isPatchingSvg) {
-        throw new Error("no available resource for reuse " + reuseTargetTid);
-      } else {
-        targetView.push(["append", nextChild]);
-        continue;
-      }
+      targetView.push(["append", nextChild]);
+      continue;
     }
 
     const rsrc = availableOwnedResource.get(reuseTargetTid)!;

--- a/addons/frontend/src/ws.ts
+++ b/addons/frontend/src/ws.ts
@@ -70,7 +70,7 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
         if (!isContentPreview) {
             subsribes.push(
                 fromEvent(window, "scroll").
-                    pipe(debounceTime(1500)).
+                    pipe(debounceTime(500)).
                     subscribe(() => svgDoc.addViewportChange())
             );
         }

--- a/addons/frontend/src/ws.ts
+++ b/addons/frontend/src/ws.ts
@@ -230,6 +230,9 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
                 }
             }
         });
+
+        const batchMessageChannel = new Subject<ArrayBuffer>();
+
         const dispose = () => {
             disposed = true;
             svgDoc.dispose();
@@ -237,11 +240,11 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
                 target.removeEventListener(evt, listener);
             }
             subject?.complete();
+            batchMessageChannel.unsubscribe();
         };
 
         // window.typstWebsocket = new WebSocket("ws://127.0.0.1:23625");
 
-        const batchMessageChannel = new Subject<ArrayBuffer>();
 
         subject.subscribe({
             next: (data) => batchMessageChannel.next(data), // Called whenever there is a message from the server.

--- a/addons/frontend/yarn.lock
+++ b/addons/frontend/yarn.lock
@@ -117,15 +117,15 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
-"@myriaddreamin/typst-ts-renderer@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst-ts-renderer/-/typst-ts-renderer-0.4.1.tgz#45f3c09ffb4363c844cbb7efe37da95fc4e4099e"
-  integrity sha512-5NXDwK0K00o+ZoMaxBlBdSsmVKY5aalolgUyTO9KNFRG3d1itsWRpRqrc1XC1dEyskGMuIqDkgwOY8vN/7T/Fw==
+"@myriaddreamin/typst-ts-renderer@0.4.2-rc1":
+  version "0.4.2-rc1"
+  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst-ts-renderer/-/typst-ts-renderer-0.4.2-rc1.tgz#9fc9baa878743367578b6e52e4209405395485e1"
+  integrity sha512-rfABholni+PVd9y+y+K4n6+T8gnYrs350wLNNAEFbOFIIfGdUSAMUrAABftMlmUTWiXQ71/xhPxzs6HE1upKOQ==
 
-"@myriaddreamin/typst.ts@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst.ts/-/typst.ts-0.4.1.tgz#7462be15631137ba3770dd42432006bb7bd2f172"
-  integrity sha512-hNkVeQaqYEt6xSuTxbDzvm0f3KkymbTGpQv6QsYyCUsa/xBzijyDN9pspW+TA+H5f9u+x1GmmGgn3bZojrHttg==
+"@myriaddreamin/typst.ts@0.4.2-rc1":
+  version "0.4.2-rc1"
+  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst.ts/-/typst.ts-0.4.2-rc1.tgz#7c3316be0c8b02740aa207b58bd918970cbc548e"
+  integrity sha512-gmwWk0EJlPTKwpgNpeIGYAvWdKeZI4HqpR54C7icppb2p6/zidoMqsT7ctwM7+pBLiIB7v+DFZZQbxqb0HY7cA==
   dependencies:
     idb "^7.1.1"
 


### PR DESCRIPTION
See title. I call it mixin rendering. I don't have good names but I just name it for the sake of convention. With mixin rendering, we can heavily debounce scroll events so to make us renderer very happy. 

https://github.com/Enter-tainer/typst-preview/assets/35292584/dcffe999-8e6b-41f7-bd94-b38f9bfda050

## Who does endly cause a scrapy scrolling? Or what are the keys to avoid scrapy scrolling?

1. You **shouldn't** change DOM heavily during scrolling event loop.
1. You **shouldn't** place too many SVG elements in window.
1. But preview has a partially rendering technique for point 2. If it doesn't rerender pages in event loop, the user will see blank pages and feel unhappy.
1. Unfortunately, the renderer changes DOM on each rendering in most common cases, failed in point 1.

## I list another solution here, which is promising but it fails now.

I made a more aggressive "mixin rendering", which rasterizes all text elements. I call it hybrid rendering. The difference between them is hybrid rendering replace more atomic elements inside of SVG to relief pressure to DOM. But it fails on preview cases.

+ It (CSS update) causes flickering update on vDOM swapping elements, while SVG update and Canvas update don't.
+ The optimization fails to deprecate partial rendering, because there will be still too many SVG elements on large document.

https://github.com/Enter-tainer/typst-preview/assets/35292584/0c4a9c8a-fa7e-4e09-9e54-840763c54086

I still view it as a promising technique, but it needs further exploring.

---

## How does this PR do?

It detects dummy pages and insert an additional canvas element into that dummy pages.

https://github.com/Enter-tainer/typst-preview/blob/65bae5fcb4398007c9a5495b2d1e8339aac03ba1/addons/frontend/src/typst-doc.ts#L540

Then, it renders canvas **incrementally** on each update event.

Finally, with mixin rendering, we can heavily debounce scroll events so to make us renderer very happy.

Todo:

+ [x] Detects empty (dummy) pages correctly.

  https://github.com/Enter-tainer/typst-preview/blob/65bae5fcb4398007c9a5495b2d1e8339aac03ba1/addons/frontend/src/typst-doc.ts#L31-L37

+ [x] Graceful strategy to restart rendering. It currently simply add a 1.5 sec debounceTime pipe to scroll event stream.

  https://github.com/Enter-tainer/typst-preview/blob/65bae5fcb4398007c9a5495b2d1e8339aac03ba1/addons/frontend/src/ws.ts#L71-L75
