### PR TITLE
fix: memory leak and DOM recalculation

### DIFF
--- a/addons/frontend/src/typst-patch.ts
+++ b/addons/frontend/src/typst-patch.ts
@@ -582,10 +582,20 @@ function patchSvgHeader(prev: SVGElement, next: SVGElement) {
         doc.body.appendChild(styleElement);
 
         const currentSvgSheet = (prevChild as HTMLStyleElement).sheet!;
+
+        let rules = new Set<string>();
+        for (const rule of currentSvgSheet.cssRules) {
+          rules.add(rule.cssText);
+        }
+
         const rulesToInsert = styleElement.sheet?.cssRules || [];
 
         // console.log("rules to insert", currentSvgSheet, rulesToInsert);
         for (const rule of rulesToInsert) {
+          if (rules.has(rule.cssText)) {
+            continue;
+          }
+          rules.add(rule.cssText);
           currentSvgSheet.insertRule(rule.cssText);
         }
       }

--- a/addons/frontend/src/ws.ts
+++ b/addons/frontend/src/ws.ts
@@ -277,13 +277,13 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
 
             const buffer = data;
             const messageData = new Uint8Array(buffer);
-            console.log('recv', messageData);
 
             const message_idx = messageData.indexOf(COMMA[0]);
             const message = [
                 dec.decode(messageData.slice(0, message_idx).buffer),
                 messageData.slice(message_idx + 1),
             ];
+            console.log('recv', message[0], messageData.length);
             // console.log(message[0], message[1].length);
             if (isContentPreview) {
                 // whether to scroll to the content preview when user updates document


### PR DESCRIPTION
These are not bug but affect performance.
+ [fix: memory leak on messageData](https://github.com/Enter-tainer/typst-preview/commit/6aa682cb88c5c651363cc14dbcb6217bc579905c)
  + console.log will reference a printed data forever.
+ [fix: try to avoid change global styles](https://github.com/Enter-tainer/typst-preview/commit/ddf420310336f9cb572a9afa1d6267400961fa83) and [fix: do early rescale to avoid recalculating entire svg document](https://github.com/Enter-tainer/typst-preview/commit/01671ed7883c91ecf67c640b2c89534f37a96782)
  + try to keep styles and attributes stable, so to reduce time on recalculating too many DOM elements.