### PR TITLE
feat: resolve spans in granularity of char

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,6 +2641,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "typst-ts-compiler"
 version = "0.4.2-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=8c6e9a41b3a65a631afd5812e43afba38c40bf11#8c6e9a41b3a65a631afd5812e43afba38c40bf11"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=57c536219e2adda14b548a43ed79e1492457853e#57c536219e2adda14b548a43ed79e1492457853e"
 dependencies = [
  "append-only-vec",
  "base64",
@@ -3439,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "typst-ts-core"
 version = "0.4.2-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=8c6e9a41b3a65a631afd5812e43afba38c40bf11#8c6e9a41b3a65a631afd5812e43afba38c40bf11"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=57c536219e2adda14b548a43ed79e1492457853e#57c536219e2adda14b548a43ed79e1492457853e"
 dependencies = [
  "base64",
  "base64-serde",
@@ -3463,6 +3474,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "serde_repr",
  "serde_with",
  "sha2",
  "siphasher 1.0.0",
@@ -3477,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "typst-ts-svg-exporter"
 version = "0.4.2-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=8c6e9a41b3a65a631afd5812e43afba38c40bf11#8c6e9a41b3a65a631afd5812e43afba38c40bf11"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=57c536219e2adda14b548a43ed79e1492457853e#57c536219e2adda14b548a43ed79e1492457853e"
 dependencies = [
  "base64",
  "comemo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,9 @@ hyper = { version = "0.14", features = ["full"] }
 [patch.crates-io]
 typst = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "typst.ts-v0.10.0-half" }
 typst-syntax = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "typst.ts-v0.10.0-half" }
-typst-ts-svg-exporter = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "8c6e9a41b3a65a631afd5812e43afba38c40bf11", package = "typst-ts-svg-exporter" }
-typst-ts-core = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "8c6e9a41b3a65a631afd5812e43afba38c40bf11", package = "typst-ts-core" }
-typst-ts-compiler = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "8c6e9a41b3a65a631afd5812e43afba38c40bf11", package = "typst-ts-compiler" }
+typst-ts-svg-exporter = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "57c536219e2adda14b548a43ed79e1492457853e", package = "typst-ts-svg-exporter" }
+typst-ts-core = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "57c536219e2adda14b548a43ed79e1492457853e", package = "typst-ts-core" }
+typst-ts-compiler = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "57c536219e2adda14b548a43ed79e1492457853e", package = "typst-ts-compiler" }
 
 # typst = { path = "../../rust/typst/crates/typst" }
 # typst-library = { path = "../../rust/typst/crates/typst-library" }

--- a/src/actor/editor.rs
+++ b/src/actor/editor.rs
@@ -154,7 +154,8 @@ impl EditorActor {
                             debug!("EditorActor: received message from editor: {:?}", jump_info);
                             let jump_info = u64::from_str_radix(&jump_info.span, 16).unwrap();
                             if let Some(span) = span_id_from_u64(jump_info) {
-                                self.world_sender.send(TypstActorRequest::DocToSrcJumpResolve(span)).unwrap();
+                                let span_and_offset = span.into();
+                                self.world_sender.send(TypstActorRequest::DocToSrcJumpResolve((span_and_offset, span_and_offset))).unwrap();
                             };
                         }
                         ControlPlaneMessage::SyncMemoryFiles(memory_files) => {

--- a/src/actor/render.rs
+++ b/src/actor/render.rs
@@ -78,10 +78,10 @@ impl RenderActor {
 
             info!("RenderActor: resolved span: {:?}", spans);
             // end position is used
-            if let Some((_, s)) = spans {
+            if let Some(spans) = spans {
                 let Ok(_) = self
                     .resolve_sender
-                    .send(TypstActorRequest::DocToSrcJumpResolve(s))
+                    .send(TypstActorRequest::DocToSrcJumpResolve(spans))
                 else {
                     info!("RenderActor: resolve_sender is dropped");
                     return false;

--- a/src/actor/webview.rs
+++ b/src/actor/webview.rs
@@ -109,7 +109,8 @@ impl WebviewActor {
                         let location = msg.split(' ').nth(1).unwrap();
                         let id = u64::from_str_radix(location, 16).unwrap();
                         if let Some(span) = span_id_from_u64(id) {
-                            let Ok(_) = self.doc_action_sender.send(TypstActorRequest::DocToSrcJumpResolve(span)) else {
+                            let span_and_offset = span.into();
+                            let Ok(_) = self.doc_action_sender.send(TypstActorRequest::DocToSrcJumpResolve((span_and_offset, span_and_offset))) else {
                                 info!("WebviewActor: failed to send DocToSrcJumpResolve message to TypstActor");
                                 break;
                             };


### PR DESCRIPTION
Corresponds to https://github.com/Myriad-Dreamin/typst.ts/pull/468

The bounding boxes of chars are calculated based of `<use>` elements and enlarged automatically. The selection fallback is calculated by:

```ts
for (const use of elem.children) {
    const useRect = use.getBoundingClientRect();
    const selRect = isHorizontalFlow() ? {
      left: useRect.left,
      right: useRect.right,
      top: textRect.top,
      bottom: textRect.bottom,
    } : {
      left: textRect.left,
      right: textRect.right,
      top: useRect.top,
      bottom: useRect.bottom,
    };
    previousSelRect = unionRect(selRect, previousSelRect);

    // set index to end range of this char
    useIndex++;
    if (inRect(selRect, mouseX, mouseY)) {
      foundIndex = useIndex;
    } else if (previousSelRect) { // may fallback to space in between chars
      if (inRect(previousSelRect, mouseX, mouseY)) {
        foundIndex = useIndex - 1;
        previousSelRect = selRect;
      }
    }
  }
```

![U1%1 BD~5R4 %(ND8_ H6UM](https://github.com/Enter-tainer/typst-preview/assets/35292584/f8a2efb7-7883-4103-a960-7aa3f4f878c2)
