### PR TITLE
feat: make cursor positions accurate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,7 +1737,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
- "owning_ref",
  "scopeguard",
 ]
 
@@ -1993,15 +1992,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "owning_ref"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
-dependencies = [
- "stable_deref_trait",
-]
 
 [[package]]
 name = "palette"
@@ -3411,8 +3401,8 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-compiler"
-version = "0.4.2-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=8e92ca47e324b0834e4537b3229d51b9e9200528#8e92ca47e324b0834e4537b3229d51b9e9200528"
+version = "0.4.2-rc6"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=c5c75842792e6e82c88833e61a3ae843fcfd41ed#c5c75842792e6e82c88833e61a3ae843fcfd41ed"
 dependencies = [
  "append-only-vec",
  "base64",
@@ -3449,8 +3439,8 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-core"
-version = "0.4.2-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=8e92ca47e324b0834e4537b3229d51b9e9200528#8e92ca47e324b0834e4537b3229d51b9e9200528"
+version = "0.4.2-rc6"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=c5c75842792e6e82c88833e61a3ae843fcfd41ed#c5c75842792e6e82c88833e61a3ae843fcfd41ed"
 dependencies = [
  "base64",
  "base64-serde",
@@ -3466,7 +3456,6 @@ dependencies = [
  "hex",
  "log",
  "once_cell",
- "owning_ref",
  "parking_lot",
  "path-clean",
  "rayon",
@@ -3478,7 +3467,6 @@ dependencies = [
  "serde_with",
  "sha2",
  "siphasher 1.0.0",
- "svgtypes",
  "tiny-skia",
  "tiny-skia-path",
  "ttf-parser",
@@ -3488,8 +3476,8 @@ dependencies = [
 
 [[package]]
 name = "typst-ts-svg-exporter"
-version = "0.4.2-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=8e92ca47e324b0834e4537b3229d51b9e9200528#8e92ca47e324b0834e4537b3229d51b9e9200528"
+version = "0.4.2-rc6"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=c5c75842792e6e82c88833e61a3ae843fcfd41ed#c5c75842792e6e82c88833e61a3ae843fcfd41ed"
 dependencies = [
  "base64",
  "comemo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3412,7 +3412,7 @@ dependencies = [
 [[package]]
 name = "typst-ts-compiler"
 version = "0.4.2-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=57c536219e2adda14b548a43ed79e1492457853e#57c536219e2adda14b548a43ed79e1492457853e"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=8e92ca47e324b0834e4537b3229d51b9e9200528#8e92ca47e324b0834e4537b3229d51b9e9200528"
 dependencies = [
  "append-only-vec",
  "base64",
@@ -3450,7 +3450,7 @@ dependencies = [
 [[package]]
 name = "typst-ts-core"
 version = "0.4.2-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=57c536219e2adda14b548a43ed79e1492457853e#57c536219e2adda14b548a43ed79e1492457853e"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=8e92ca47e324b0834e4537b3229d51b9e9200528#8e92ca47e324b0834e4537b3229d51b9e9200528"
 dependencies = [
  "base64",
  "base64-serde",
@@ -3489,7 +3489,7 @@ dependencies = [
 [[package]]
 name = "typst-ts-svg-exporter"
 version = "0.4.2-rc5"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=57c536219e2adda14b548a43ed79e1492457853e#57c536219e2adda14b548a43ed79e1492457853e"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=8e92ca47e324b0834e4537b3229d51b9e9200528#8e92ca47e324b0834e4537b3229d51b9e9200528"
 dependencies = [
  "base64",
  "comemo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,7 +3402,7 @@ dependencies = [
 [[package]]
 name = "typst-ts-compiler"
 version = "0.4.2-rc6"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=c5c75842792e6e82c88833e61a3ae843fcfd41ed#c5c75842792e6e82c88833e61a3ae843fcfd41ed"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=98e3d3a42877b195f87223060882d55fd5aaa04a#98e3d3a42877b195f87223060882d55fd5aaa04a"
 dependencies = [
  "append-only-vec",
  "base64",
@@ -3440,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "typst-ts-core"
 version = "0.4.2-rc6"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=c5c75842792e6e82c88833e61a3ae843fcfd41ed#c5c75842792e6e82c88833e61a3ae843fcfd41ed"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=98e3d3a42877b195f87223060882d55fd5aaa04a#98e3d3a42877b195f87223060882d55fd5aaa04a"
 dependencies = [
  "base64",
  "base64-serde",
@@ -3477,7 +3477,7 @@ dependencies = [
 [[package]]
 name = "typst-ts-svg-exporter"
 version = "0.4.2-rc6"
-source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=c5c75842792e6e82c88833e61a3ae843fcfd41ed#c5c75842792e6e82c88833e61a3ae843fcfd41ed"
+source = "git+https://github.com/Myriad-Dreamin/typst.ts?rev=98e3d3a42877b195f87223060882d55fd5aaa04a#98e3d3a42877b195f87223060882d55fd5aaa04a"
 dependencies = [
  "base64",
  "comemo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ doc = false
 [dependencies]
 typst = "0.10.0"
 # typst-library = "0.10.0"
-typst-ts-svg-exporter = "0.4.2-rc5"
-typst-ts-core = { version = "0.4.2-rc5", default-features = false, features = [
+typst-ts-svg-exporter = "0.4.2-rc6"
+typst-ts-core = { version = "0.4.2-rc6", default-features = false, features = [
   "flat-vector",
   "vector-bbox",
   "no-content-hint",
 ] }
-typst-ts-compiler = "0.4.2-rc5"
+typst-ts-compiler = "0.4.2-rc6"
 
 chrono = { version = "0.4", default-features = false, features = [
   "clock",
@@ -56,9 +56,9 @@ hyper = { version = "0.14", features = ["full"] }
 [patch.crates-io]
 typst = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "typst.ts-v0.10.0-half" }
 typst-syntax = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "typst.ts-v0.10.0-half" }
-typst-ts-svg-exporter = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "8e92ca47e324b0834e4537b3229d51b9e9200528", package = "typst-ts-svg-exporter" }
-typst-ts-core = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "8e92ca47e324b0834e4537b3229d51b9e9200528", package = "typst-ts-core" }
-typst-ts-compiler = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "8e92ca47e324b0834e4537b3229d51b9e9200528", package = "typst-ts-compiler" }
+typst-ts-svg-exporter = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "c5c75842792e6e82c88833e61a3ae843fcfd41ed", package = "typst-ts-svg-exporter" }
+typst-ts-core = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "c5c75842792e6e82c88833e61a3ae843fcfd41ed", package = "typst-ts-core" }
+typst-ts-compiler = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "c5c75842792e6e82c88833e61a3ae843fcfd41ed", package = "typst-ts-compiler" }
 
 # typst = { path = "../../rust/typst/crates/typst" }
 # typst-library = { path = "../../rust/typst/crates/typst-library" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,9 @@ hyper = { version = "0.14", features = ["full"] }
 [patch.crates-io]
 typst = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "typst.ts-v0.10.0-half" }
 typst-syntax = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "typst.ts-v0.10.0-half" }
-typst-ts-svg-exporter = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "57c536219e2adda14b548a43ed79e1492457853e", package = "typst-ts-svg-exporter" }
-typst-ts-core = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "57c536219e2adda14b548a43ed79e1492457853e", package = "typst-ts-core" }
-typst-ts-compiler = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "57c536219e2adda14b548a43ed79e1492457853e", package = "typst-ts-compiler" }
+typst-ts-svg-exporter = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "8e92ca47e324b0834e4537b3229d51b9e9200528", package = "typst-ts-svg-exporter" }
+typst-ts-core = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "8e92ca47e324b0834e4537b3229d51b9e9200528", package = "typst-ts-core" }
+typst-ts-compiler = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "8e92ca47e324b0834e4537b3229d51b9e9200528", package = "typst-ts-compiler" }
 
 # typst = { path = "../../rust/typst/crates/typst" }
 # typst-library = { path = "../../rust/typst/crates/typst-library" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,9 @@ hyper = { version = "0.14", features = ["full"] }
 [patch.crates-io]
 typst = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "typst.ts-v0.10.0-half" }
 typst-syntax = { git = "https://github.com/Myriad-Dreamin/typst.git", branch = "typst.ts-v0.10.0-half" }
-typst-ts-svg-exporter = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "c5c75842792e6e82c88833e61a3ae843fcfd41ed", package = "typst-ts-svg-exporter" }
-typst-ts-core = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "c5c75842792e6e82c88833e61a3ae843fcfd41ed", package = "typst-ts-core" }
-typst-ts-compiler = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "c5c75842792e6e82c88833e61a3ae843fcfd41ed", package = "typst-ts-compiler" }
+typst-ts-svg-exporter = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "98e3d3a42877b195f87223060882d55fd5aaa04a", package = "typst-ts-svg-exporter" }
+typst-ts-core = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "98e3d3a42877b195f87223060882d55fd5aaa04a", package = "typst-ts-core" }
+typst-ts-compiler = { git = "https://github.com/Myriad-Dreamin/typst.ts", rev = "98e3d3a42877b195f87223060882d55fd5aaa04a", package = "typst-ts-compiler" }
 
 # typst = { path = "../../rust/typst/crates/typst" }
 # typst-library = { path = "../../rust/typst/crates/typst-library" }

--- a/addons/frontend/package.json
+++ b/addons/frontend/package.json
@@ -12,8 +12,8 @@
     "link:local": "yarn link @myriaddreamin/typst.ts @myriaddreamin/typst-ts-renderer"
   },
   "dependencies": {
-    "@myriaddreamin/typst-ts-renderer": "0.4.2-rc5",
-    "@myriaddreamin/typst.ts": "0.4.2-rc5",
+    "@myriaddreamin/typst-ts-renderer": "0.4.2-rc6",
+    "@myriaddreamin/typst.ts": "0.4.2-rc6",
     "typst-dom": "link:../typst-dom",
     "rxjs": "^7.8.1"
   },

--- a/addons/frontend/src/typst.css
+++ b/addons/frontend/src/typst.css
@@ -139,7 +139,9 @@ path.outline_glyph {
 }
 
 .typst-svg-cursor {
-  animation: 1s blink step-start infinite;
+  /* https://www.elevenforum.com/t/change-text-cursor-blink-rate-in-windows-11.12409/ */
+  /* 1.2 seconds per blink is the default value on gtk and the slowest value on windows */
+  animation: 1.2s blink step-start infinite;
 }
 
 @keyframes blink {

--- a/addons/frontend/src/typst.css
+++ b/addons/frontend/src/typst.css
@@ -137,3 +137,13 @@ path.outline_glyph {
     margin: -1.5vw;
   }
 }
+
+.typst-svg-cursor {
+  animation: 1s blink step-start infinite;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}

--- a/addons/frontend/src/ws.ts
+++ b/addons/frontend/src/ws.ts
@@ -345,6 +345,13 @@ export async function wsMain({ url, previewMode, isContentPreview }: WsArgs) {
                 svgDoc.setCursor(page, x, y);
                 svgDoc.addViewportChange(); // todo: synthesizing cursor event
                 return;
+            } else if (message[0] === "cursor-paths") {
+                // todo: aware height padding
+                const paths = JSON.parse(dec
+                    .decode((message[1] as any).buffer));
+                console.log("cursor-paths", paths);
+                svgDoc.impl.setCursorPaths(paths);
+                return;
             } else if (message[0] === "partial-rendering") {
                 console.log("Experimental feature: partial rendering enabled");
                 svgDoc.setPartialRendering(true);

--- a/addons/frontend/yarn.lock
+++ b/addons/frontend/yarn.lock
@@ -117,15 +117,15 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
-"@myriaddreamin/typst-ts-renderer@0.4.2-rc5":
-  version "0.4.2-rc5"
-  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst-ts-renderer/-/typst-ts-renderer-0.4.2-rc5.tgz#f6671411ce4ae607a6618796cf53f93e611db186"
-  integrity sha512-u7UPPGF3ZrXbhbGqZscUVf0q5GM1V/ITFTe1R+m9zoJKwUfSGibcldtIQT6E9iwNfeSggYkn/eWNSFhYXaFHRQ==
+"@myriaddreamin/typst-ts-renderer@0.4.2-rc6":
+  version "0.4.2-rc6"
+  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst-ts-renderer/-/typst-ts-renderer-0.4.2-rc6.tgz#d6096323cdc4706f61b525ce81345e1db7ad88cf"
+  integrity sha512-H897+w+NAHHcBeQM3IHk00No2wHHVownPpnl0xl8/4ibbJnpXAmtCEo6ZleFzIZVqyB8zRDH6FKaZ6j9RsDcMw==
 
-"@myriaddreamin/typst.ts@0.4.2-rc5":
-  version "0.4.2-rc5"
-  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst.ts/-/typst.ts-0.4.2-rc5.tgz#97c41cd11144aced046e2faf6daa78c637696c77"
-  integrity sha512-DtACv50NI4uKaccY+ijiLQII5yolcjjswhE7kcXrlYR5wxhebNrlaLGGsU0XOslv/PWuUrDLKV2mUSDIJg2hxw==
+"@myriaddreamin/typst.ts@0.4.2-rc6":
+  version "0.4.2-rc6"
+  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst.ts/-/typst.ts-0.4.2-rc6.tgz#41e39f5e85faa421bb2c7488a709ce71a0a0606b"
+  integrity sha512-bCEWYK/H7Uls/pzOKi9dTABgblSnj4uWJiDCVLTXtknxyXqgeicT8YaVtI2mOhv1CZ22SiPmgma/gtCW0ecqlw==
   dependencies:
     idb "^7.1.1"
 

--- a/addons/typst-dom/package.json
+++ b/addons/typst-dom/package.json
@@ -12,12 +12,12 @@
     "link:local": "yarn link @myriaddreamin/typst.ts @myriaddreamin/typst-ts-renderer"
   },
   "peerDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "0.4.2-rc5",
-    "@myriaddreamin/typst.ts": "0.4.2-rc5"
+    "@myriaddreamin/typst-ts-renderer": "0.4.2-rc6",
+    "@myriaddreamin/typst.ts": "0.4.2-rc6"
   },
   "devDependencies": {
-    "@myriaddreamin/typst-ts-renderer": "0.4.2-rc5",
-    "@myriaddreamin/typst.ts": "0.4.2-rc5",
+    "@myriaddreamin/typst-ts-renderer": "0.4.2-rc6",
+    "@myriaddreamin/typst.ts": "0.4.2-rc6",
     "typescript": "^5.0.2",
     "vite": "^4.3.9",
     "vite-plugin-singlefile": "^0.13.5",

--- a/addons/typst-dom/src/typst-debug-info.mts
+++ b/addons/typst-dom/src/typst-debug-info.mts
@@ -80,6 +80,30 @@ function findIndexOfChild(elem: Element, child: Element) {
   return children.findIndex((x) => x[1] === child);
 }
 
+export function resolveSourceLeaf(elem: Element, path: [number, number, string][]): [Element, number] | undefined {
+  const page = elem.getElementsByClassName('typst-page')[0];
+  let curElem = page;
+
+  for (const idx of path.slice(1)) {
+    if (idx[0] === SourceMappingType.CharIndex) {
+      // console.log('done char');
+      return [curElem, idx[1]];
+    }
+    const children = castChildrenToSourceMappingElement(curElem);
+    console.log(idx, children);
+    if (idx[1] >= children.length) {
+      return undefined;
+    }
+    if (idx[0] != children[idx[1]][0]) {
+      return undefined;
+    }
+    curElem = children[idx[1]][1];
+  }
+
+  // console.log('done');
+  return [curElem, 0];
+}
+
 // const rotateColors = [
 //   "green",
 //   "blue",
@@ -330,7 +354,8 @@ export function installEditorJumpToHandler(svgDoc: any, docRoot: HTMLElement) {
   docRoot.addEventListener("click", sourceMappingHandler);
 }
 
-export interface TypstDebugJumpDocument { }
+export interface TypstDebugJumpDocument {
+}
 
 export function provideDebugJumpDoc<
   TBase extends GConstructor<TypstDocumentContext>

--- a/addons/typst-dom/src/typst-debug-info.mts
+++ b/addons/typst-dom/src/typst-debug-info.mts
@@ -10,6 +10,12 @@ const enum SourceMappingType {
   CharIndex = 5,
 }
 
+export interface ElementPoint {
+  kind: number;
+  index: number;
+  fingerprint: string;
+}
+
 // one-of following classes must be present:
 // - typst-page
 // - typst-group
@@ -80,24 +86,24 @@ function findIndexOfChild(elem: Element, child: Element) {
   return children.findIndex((x) => x[1] === child);
 }
 
-export function resolveSourceLeaf(elem: Element, path: [number, number, string][]): [Element, number] | undefined {
+export function resolveSourceLeaf(elem: Element, path: ElementPoint[]): [Element, number] | undefined {
   const page = elem.getElementsByClassName('typst-page')[0];
   let curElem = page;
 
-  for (const idx of path.slice(1)) {
-    if (idx[0] === SourceMappingType.CharIndex) {
+  for (const point of path.slice(1)) {
+    if (point.kind === SourceMappingType.CharIndex) {
       // console.log('done char');
-      return [curElem, idx[1]];
+      return [curElem, point.index];
     }
     const children = castChildrenToSourceMappingElement(curElem);
-    console.log(idx, children);
-    if (idx[1] >= children.length) {
+    console.log(point, children);
+    if (point.index >= children.length) {
       return undefined;
     }
-    if (idx[0] != children[idx[1]][0]) {
+    if (point.kind != children[point.index][0]) {
       return undefined;
     }
-    curElem = children[idx[1]][1];
+    curElem = children[point.index][1];
   }
 
   // console.log('done');

--- a/addons/typst-dom/src/typst-doc.svg.mts
+++ b/addons/typst-dom/src/typst-doc.svg.mts
@@ -69,10 +69,11 @@ export function provideSvgDoc<
             continue;
           }
           console.log('svg post check cursorPaths leaf', leaf);
+
+          // Finds glyphs in the text element
           let useIdx = 0;
           let foundUse: SVGUseElement | undefined = undefined;
           let foundUseNext: SVGUseElement | undefined = undefined;
-          // let foundUseNext = undefined;
           for (const use of leaf[0].children) {
             if (use.tagName === 'use') {
               useIdx++;
@@ -87,52 +88,40 @@ export function provideSvgDoc<
           }
 
           if (foundUse !== undefined) {
-            // put them inside of svg instead
-            // const rect = foundUse.getBoundingClientRect();
-            // get rect inside of the group
             const g = leaf[0] as SVGGraphicsElement;
             // const textBase = g.getBBox();
             const rectBase = foundUse.getBBox();
             const rectNextBase = foundUseNext?.getBBox();
-            // const rectX = Number.parseFloat(foundUse.getAttribute('x')!);
             const rect = {
-              // right: rectX + rectBase.x + rectBase.width,
+              // Some char does not have position so they are resolved to 0
               right: (rectBase.width !== 0) ? (rectBase.x + rectBase.width) : (rectNextBase?.x || 0),
               // todo: have bug
               // top: textBase.height / 2,
             }
-            const t = document.createElementNS("http://www.w3.org/2000/svg", "ellipse");
-            t.classList.add('typst-svg-cursor');
-            t.setAttribute('cx', `${rect.right}`);
-            // t.setAttribute('cy', `${rect.top}`);
-            // t.setAttribute('r', '5');
-            // get transform matrix
-            // const mat = g.transform.baseVal.consolidate()?.matrix;
+            // Gets transform matrix
             const mat = g.getScreenCTM();
-            // set correct radius
+            // Calculates correct 5px radius
             let rx = 5;
             let ry = 5;
-            // console.log('svg post check cursorPaths mat', textBase, rectBase, rectNextBase, mat);
             const matInv = mat?.inverse();
             if (matInv) {
-              // console.log('svg post check cursorPaths matInv', matInv);
-              // r = r * matInv.a;
-              // consider scale and skew
               const sx = matInv.a;
               const ky = matInv.b;
               const kx = matInv.c;
               const sy = matInv.d;
-              // x' = x * sx + y * kx + tx
-              // y' = x * ky + y * sy + ty
 
               const rrx = rx * sx + ry * kx;
               const rry = ry * sy + rx * ky;
               rx = rrx;
               ry = rry;
             }
-
             rx = Math.abs(rx);
             ry = Math.abs(ry);
+
+            const t = document.createElementNS("http://www.w3.org/2000/svg", "ellipse");
+            t.classList.add('typst-svg-cursor');
+            t.setAttribute('cx', `${rect.right}`);
+            // t.setAttribute('cy', `${rect.top}`);
             t.setAttribute('rx', `${rx}`);
             t.setAttribute('ry', `${ry}`);
             t.setAttribute('fill', '#86C16688');

--- a/addons/typst-dom/src/typst-doc.svg.mts
+++ b/addons/typst-dom/src/typst-doc.svg.mts
@@ -4,10 +4,10 @@ import { TypstPatchAttrs, isDummyPatchElem } from "./typst-patch.mjs";
 import type { GConstructor, TypstDocumentContext } from "./typst-doc.mjs";
 import type { CanvasPage, TypstCanvasDocument } from "./typst-doc.canvas.mjs";
 import { patchSvgToContainer } from "./typst-patch.svg.mjs";
-import { resolveSourceLeaf } from "./typst-debug-info.mjs";
+import { ElementPoint, resolveSourceLeaf } from "./typst-debug-info.mjs";
 
 export interface TypstSvgDocument {
-  setCursorPaths(paths: [number, number, string][][]): void;
+  setCursorPaths(paths: ElementPoint[][]): void;
 }
 
 export function provideSvgDoc<
@@ -25,9 +25,9 @@ export function provideSvgDoc<
       return !!this.feat$canvas;
     }
 
-    /// cursor position in form of [page, x, y]
-    cursorPaths?: [number, number, string][][] = undefined;
-    setCursorPaths(paths: [number, number, string][][]) {
+    /// cursor path is a list of element point from root to leaf
+    cursorPaths?: ElementPoint[][] = undefined;
+    setCursorPaths(paths: ElementPoint[][]) {
       this.cursorPaths = paths;
       this.addViewportChange();
     }

--- a/addons/typst-dom/src/typst-doc.svg.mts
+++ b/addons/typst-dom/src/typst-doc.svg.mts
@@ -62,6 +62,8 @@ export function provideSvgDoc<
           c.remove();
         }
         console.log('svg post check cursorPaths', this.cursorPaths);
+
+        // Draw cursors by element paths
         for (const p of this.cursorPaths) {
           const leaf = resolveSourceLeaf(this.hookedElem, p);
           if (!leaf) {
@@ -87,6 +89,8 @@ export function provideSvgDoc<
             }
           }
 
+          // Draws cursor at text position
+          // todo: draw cursor for image and shape elements
           if (foundUse !== undefined) {
             const g = leaf[0] as SVGGraphicsElement;
             // const textBase = g.getBBox();
@@ -98,8 +102,10 @@ export function provideSvgDoc<
               // todo: have bug
               // top: textBase.height / 2,
             }
+
             // Gets transform matrix
             const mat = g.getScreenCTM();
+
             // Calculates correct 5px radius
             let rx = 5;
             let ry = 5;
@@ -118,6 +124,7 @@ export function provideSvgDoc<
             rx = Math.abs(rx);
             ry = Math.abs(ry);
 
+            // Creates a circle with 5px radius (but regard vertical and horizontal scale)
             const t = document.createElementNS("http://www.w3.org/2000/svg", "ellipse");
             t.classList.add('typst-svg-cursor');
             t.setAttribute('cx', `${rect.right}`);

--- a/addons/typst-dom/yarn.lock
+++ b/addons/typst-dom/yarn.lock
@@ -124,15 +124,15 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
-"@myriaddreamin/typst-ts-renderer@0.4.2-rc5":
-  version "0.4.2-rc5"
-  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst-ts-renderer/-/typst-ts-renderer-0.4.2-rc5.tgz#f6671411ce4ae607a6618796cf53f93e611db186"
-  integrity sha512-u7UPPGF3ZrXbhbGqZscUVf0q5GM1V/ITFTe1R+m9zoJKwUfSGibcldtIQT6E9iwNfeSggYkn/eWNSFhYXaFHRQ==
+"@myriaddreamin/typst-ts-renderer@0.4.2-rc6":
+  version "0.4.2-rc6"
+  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst-ts-renderer/-/typst-ts-renderer-0.4.2-rc6.tgz#d6096323cdc4706f61b525ce81345e1db7ad88cf"
+  integrity sha512-H897+w+NAHHcBeQM3IHk00No2wHHVownPpnl0xl8/4ibbJnpXAmtCEo6ZleFzIZVqyB8zRDH6FKaZ6j9RsDcMw==
 
-"@myriaddreamin/typst.ts@0.4.2-rc5":
-  version "0.4.2-rc5"
-  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst.ts/-/typst.ts-0.4.2-rc5.tgz#97c41cd11144aced046e2faf6daa78c637696c77"
-  integrity sha512-DtACv50NI4uKaccY+ijiLQII5yolcjjswhE7kcXrlYR5wxhebNrlaLGGsU0XOslv/PWuUrDLKV2mUSDIJg2hxw==
+"@myriaddreamin/typst.ts@0.4.2-rc6":
+  version "0.4.2-rc6"
+  resolved "https://registry.yarnpkg.com/@myriaddreamin/typst.ts/-/typst.ts-0.4.2-rc6.tgz#41e39f5e85faa421bb2c7488a709ce71a0a0606b"
+  integrity sha512-bCEWYK/H7Uls/pzOKi9dTABgblSnj4uWJiDCVLTXtknxyXqgeicT8YaVtI2mOhv1CZ22SiPmgma/gtCW0ecqlw==
   dependencies:
     idb "^7.1.1"
 

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -176,6 +176,12 @@ const sendDocRequest = async (bindDocument: vscode.TextDocument | undefined, scr
 };
 
 const reportPosition = async (bindDocument: vscode.TextDocument, activeEditor: vscode.TextEditor, event: string) => {
+	// extension-output
+	if (bindDocument.uri.fsPath.includes('extension-output')) {
+		console.log('skip extension-output file', bindDocument.uri.fsPath);
+		return;
+	}
+
 	const scrollRequest: ScrollRequest = {
 		event,
 		'filepath': bindDocument.uri.fsPath,

--- a/src/actor/render.rs
+++ b/src/actor/render.rs
@@ -1,16 +1,15 @@
 use std::sync::Arc;
 
 use log::{debug, info, trace};
-use serde::Deserialize;
 use tokio::sync::{broadcast, mpsc, watch};
 use typst::model::Document;
-use typst_ts_core::debug_loc::SourceSpanOffset;
+use typst_ts_core::debug_loc::{ElementPoint, SourceSpanOffset};
 use typst_ts_svg_exporter::IncrSvgDocServer;
 
 use super::{editor::EditorActorRequest, typst::TypstActorRequest, webview::WebviewActorRequest};
 
-#[derive(Debug, Clone, Deserialize)]
-pub struct ResolveSpanRequest(Vec<(u32, u32, String)>);
+#[derive(Debug, Clone)]
+pub struct ResolveSpanRequest(pub Vec<ElementPoint>);
 
 #[derive(Debug, Clone)]
 pub enum RenderActorRequest {

--- a/src/actor/webview.rs
+++ b/src/actor/webview.rs
@@ -10,14 +10,15 @@ use typst_ts_core::vector::span_id_from_u64;
 use super::{render::RenderActorRequest, typst::TypstActorRequest};
 use crate::debug_loc::DocumentPosition;
 
-pub type CursorPosition = DocumentPosition;
+// pub type CursorPosition = DocumentPosition;
 pub type SrcToDocJumpInfo = DocumentPosition;
 
 #[derive(Debug, Clone)]
 pub enum WebviewActorRequest {
     ViewportPosition(DocumentPosition),
     SrcToDocJump(SrcToDocJumpInfo),
-    CursorPosition(CursorPosition),
+    // CursorPosition(CursorPosition),
+    CursorPaths(Vec<Vec<(u32, u32, String)>>),
 }
 
 fn position_req(
@@ -82,8 +83,13 @@ impl WebviewActor {
                             let msg = position_req("viewport", jump_info);
                             self.webview_websocket_conn.send(Message::Binary(msg.into_bytes())).await.unwrap();
                         }
-                        WebviewActorRequest::CursorPosition(jump_info) => {
-                            let msg = position_req("cursor", jump_info);
+                        // WebviewActorRequest::CursorPosition(jump_info) => {
+                        //     let msg = position_req("cursor", jump_info);
+                        //     self.webview_websocket_conn.send(Message::Binary(msg.into_bytes())).await.unwrap();
+                        // }
+                        WebviewActorRequest::CursorPaths(jump_info) => {
+                            let json = serde_json::to_string(&jump_info).unwrap();
+                            let msg = format!("cursor-paths,{json}");
                             self.webview_websocket_conn.send(Message::Binary(msg.into_bytes())).await.unwrap();
                         }
                     }


### PR DESCRIPTION
Previous, cursor position are represented by `page,x,y` generated by `jump_from_cursor`, but it is a bit coarse. Now, we change the approach a bit, which contains several steps:
+ editor extension reports a cursor change event, containing (file, line, column) of the cursor.
  + editor actor receives it and pass it to typst actor.
+ typst actor finds a corresponding (span, inner-offset) by (file, line, column).
  + typst actor locks the world, and finds a span with inner byte offset in the source file's AST.
  + typst send change cursor request to renderer, containing (span, inner-offset) of the cursor.
+ renderer actor finds the corresponding element paths (path from vector IR's root to some leaf) by (span, inner-offset).
  + it queries all leaves owning `span`. If there is a inner-offset, it also locates a sub-index inside of the element. For example, a char offset in the text element.
  + for each leaf, it iterates the the parent map until the root of the span tree, forming an inversed path from root to leaf.
  + renderer actor sends all valid element paths to webview client.
+ webview client receives a set of element paths.
  + After each rendering of SVG, it sees all current element paths of cursor.
  + It locates the SVG leaf elements down to path.
  + It puts a cursor having width of 5px accurately at the leaf elements, leveraging SVG bounding boxes and transform matrixes.

typst actor cannot resolves element paths but renderer actor can, since:
  + the vector IR (representing elements) is generated at render stage.
  + When lowering the vector IR, a lazy span tree is generated at the same time, having the same shape as the vector IR.

In new approach, server doesn't perform geometrics at all but to find all elements about the source location, and client locate SVG elements by path and put cursors accurately on the SVG.

![image](https://github.com/Enter-tainer/typst-preview/assets/35292584/5b02f179-c28d-4b91-a958-e78ad8c939d1)
