### PR TITLE
feat: get dark theme for free by the `invert-colors` option

### DIFF
--- a/addons/frontend/src/typst.css
+++ b/addons/frontend/src/typst.css
@@ -39,7 +39,7 @@ body {
 }
 
 #typst-app.invert-colors {
-  filter: invert(0.95) hue-rotate(180deg);
+  filter: invert(0.933333) hue-rotate(180deg);
 }
 
 #typst-app.invert-colors .typst-image {

--- a/addons/frontend/src/typst.css
+++ b/addons/frontend/src/typst.css
@@ -48,7 +48,7 @@ body {
 }
 
 #typst-app.invert-colors .typst-image:hover {
-  filter: invert(0.95) hue-rotate(180deg);
+  filter: invert(1) hue-rotate(180deg);
 }
 .hide-scrollbar-x {
   overflow-x: hidden;

--- a/addons/frontend/src/typst.css
+++ b/addons/frontend/src/typst.css
@@ -39,16 +39,16 @@ body {
 }
 
 #typst-app.invert-colors {
-  filter: invert(1);
+  filter: invert(0.95) hue-rotate(180deg);
 }
 
 #typst-app.invert-colors .typst-image {
-  filter: invert(0);
+  filter: invert(0) hue-rotate(0deg);
   transition: filter 0.1s ease-in-out;
 }
 
 #typst-app.invert-colors .typst-image:hover {
-  filter: invert(1);
+  filter: invert(0.95) hue-rotate(180deg);
 }
 .hide-scrollbar-x {
   overflow-x: hidden;

--- a/addons/frontend/src/typst.css
+++ b/addons/frontend/src/typst.css
@@ -38,6 +38,18 @@ body {
   background-color: #fff;
 }
 
+#typst-app.invert-colors {
+  filter: invert(1);
+}
+
+#typst-app.invert-colors .typst-image {
+  filter: invert(0);
+  transition: filter 0.1s ease-in-out;
+}
+
+#typst-app.invert-colors .typst-image:hover {
+  filter: invert(1);
+}
 .hide-scrollbar-x {
   overflow-x: hidden;
 }

--- a/addons/frontend/src/ws.ts
+++ b/addons/frontend/src/ws.ts
@@ -428,7 +428,7 @@ function ensureInvertColors(root: HTMLElement | null, strategy: string) {
 
 
             if (themeIsDark) {
-                console.log("invert-colors because detected by --typst-preview-vscode-preferred-theme");
+                console.log("invert-colors because detected by vscode theme", document.body.className);
                 return true;
             }
         } else {

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -175,6 +175,21 @@
           "type": "boolean",
           "default": true
         },
+        "typst-preview.invertColors": {
+          "description": "Invert colors of the preview (useful for dark themes without cost). Please note you could see the origin colors when you hover elements in the preview.",
+          "type": "string",
+          "enum": [
+            "never",
+            "auto",
+            "always"
+          ],
+          "default": "never",
+          "enumDescriptions": [
+            "Disable color inversion of the preview",
+            "Invert colors smartly by detecting dark/light themes in browser environment or by `typst query` your document",
+            "Always invert colors of the preview"
+          ]
+        },
         "typst-preview.cursorIndicator": {
           "description": "(Experimental) Show typst cursor indicator in preview.",
           "type": "boolean",

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -504,6 +504,8 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 		const projectRoot = getProjectRoot(filePath);
 		const rootArgs = ["--root", projectRoot];
 		const partialRenderingArgs = vscode.workspace.getConfiguration().get<boolean>('typst-preview.partialRendering') ? ["--partial-rendering"] : [];
+		const ivArgs = vscode.workspace.getConfiguration().get<string>('typst-preview.invertColors');
+		const invertColorsArgs = ivArgs ? ["--invert-colors", ivArgs] : [];
 		const previewInSlideModeArgs = task.mode === 'slide' ? ["--preview-mode=slide"] : [];
 		const { dataPlanePort, controlPlanePort, staticFilePort, serverProcess } = await runServer(serverPath, [
 			"--data-plane-host", "127.0.0.1:0",
@@ -512,6 +514,7 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 			"--no-open",
 			...rootArgs,
 			...partialRenderingArgs,
+			...invertColorsArgs,
 			...previewInSlideModeArgs,
 			...codeGetCliFontArgs(),
 			filePath,

--- a/src/args.rs
+++ b/src/args.rs
@@ -37,9 +37,16 @@ pub struct PreviewArgs {
     )]
     pub control_plane_host: String,
 
-    /// Only render visible part of the document. This can improve performance but still being experimental.
+    /// Only render visible part of the document. This can improve performance
+    /// but still being experimental.
     #[clap(long = "partial-rendering")]
     pub enable_partial_rendering: bool,
+
+    /// Invert colors of the preview (useful for dark themes without cost).
+    /// Please note you could see the origin colors when you hover elements in
+    /// the preview.
+    #[clap(long, default_value = "never")]
+    pub invert_colors: String,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ pub trait CompileHost {
 // todo: replace CompileDriver by CompileHost
 pub async fn preview(arguments: PreviewArgs, compiler_driver: CompileDriver) -> Previewer {
     let enable_partial_rendering = arguments.enable_partial_rendering;
+    let invert_colors = arguments.invert_colors;
 
     // Create the world that serves sources, fonts and files.
     let actor::typst::Channels {
@@ -165,6 +166,13 @@ pub async fn preview(arguments: PreviewArgs, compiler_driver: CompileDriver) -> 
                     conn.send(Message::Binary("partial-rendering,true".into()))
                         .await
                         .unwrap();
+                }
+                if !invert_colors.is_empty() {
+                    conn.send(Message::Binary(
+                        format!("invert-colors,{}", invert_colors).into(),
+                    ))
+                    .await
+                    .unwrap();
                 }
                 let actor::webview::Channels { svg } =
                     actor::webview::WebviewActor::set_up_channels();


### PR DESCRIPTION
Provides an option:
```jsonc
"typst-preview.invertColors": {
  "description": "Invert colors of the preview (useful for dark themes without cost). Please note you could see the origin colors when you hover elements in the preview.",
  "type": "string",
  "enum": [
    "never",
    "auto",
    "always"
  ],
  "default": "never",
  "enumDescriptions": [
    "Disable color inversion of the preview",
    "Invert colors smartly by detecting dark/light themes in browser environment or by `typst query` your document",
    "Always invert colors of the preview"
  ]
}
```

It inverts all color of items, but when you hover on images, they are back to origin color to help read content inside.

![image](https://github.com/Enter-tainer/typst-preview/assets/35292584/132be2e4-9cca-418b-9d61-e6ce04d3caab)

The `` `typst query` your document `` in auto is not implemented but I want to leave it in the initial feature PR, to remind users you can wait for a feature to disable it for specific templates (documents).
