### PR TITLE
feat: auto scroll sync by keyboard events

### DIFF
--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -162,12 +162,14 @@
           "type": "string",
           "enum": [
             "never",
-            "onSelectionChange"
+            "onSelectionChange",
+            "onAnyChange"
           ],
           "default": "onSelectionChange",
           "enumDescriptions": [
             "Disable automatic scroll sync",
-            "Scroll preview to current cursor position when selection changes"
+            "Scroll preview to current cursor position when selection changes by mouse",
+            "Scroll preview to current cursor position when selection changes by mouse or keyboard (any source)"
           ]
         },
         "typst-preview.partialRendering": {

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -162,10 +162,10 @@
           "type": "string",
           "enum": [
             "never",
-            "onSelectionChange",
-            "onAnyChange"
+            "onSelectionChangeByMouse",
+            "onSelectionChange"
           ],
-          "default": "onSelectionChange",
+          "default": "onSelectionChangeByMouse",
           "enumDescriptions": [
             "Disable automatic scroll sync",
             "Scroll preview to current cursor position when selection changes by mouse",

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -19,7 +19,13 @@ let outlineProvider = new Promise<OutlineProvider>(resolve => {
 	resolveOutlineProvider = resolve;
 });
 
-type ScrollSyncMode = "never" | "onSelectionChange";
+enum ScrollSyncModeEnum {
+	never,
+	onSelectionChange,
+	onAnyChange,
+}
+
+type ScrollSyncMode = "never" | "onSelectionChange" | "onAnyChange";
 
 async function loadHTMLFile(context: vscode.ExtensionContext, relativePath: string) {
 	const filePath = path.resolve(context.extensionPath, relativePath);
@@ -333,7 +339,7 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 	const filePath = bindDocument.uri.fsPath;
 
 	const refreshStyle = vscode.workspace.getConfiguration().get<string>('typst-preview.refresh') || "onSave";
-	const scrollSyncMode = vscode.workspace.getConfiguration().get<ScrollSyncMode>('typst-preview.scrollSync') || "never";
+	const scrollSyncMode = ScrollSyncModeEnum[vscode.workspace.getConfiguration().get<ScrollSyncMode>('typst-preview.scrollSync') || "never"];
 	const enableCursor = vscode.workspace.getConfiguration().get<boolean>('typst-preview.cursorIndicator') || false;
 	const fontendPath = path.resolve(context.extensionPath, "out/frontend");
 	await watchEditorFiles();
@@ -381,7 +387,12 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 
 			const kind = e.kind;
 			console.log(`selection changed, kind: ${kind && vscode.TextEditorSelectionChangeKind[kind]}`);
-			if (kind === vscode.TextEditorSelectionChangeKind.Mouse) {
+			const shouldScrollPanel = (
+				// scroll by mouse
+				(scrollSyncMode !== ScrollSyncModeEnum.never && kind === vscode.TextEditorSelectionChangeKind.Mouse)
+				// scroll by keyboard typing
+				|| (scrollSyncMode === ScrollSyncModeEnum.onAnyChange && kind === vscode.TextEditorSelectionChangeKind.Keyboard));
+			if (shouldScrollPanel) {
 				console.log(`selection changed, sending src2doc jump request`);
 				reportPosition(doc, editor, 'panelScrollTo');
 			}
@@ -392,7 +403,7 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 		}
 	};
 	const src2docHandlerDispose =
-		scrollSyncMode === "onSelectionChange"
+		scrollSyncMode !== ScrollSyncModeEnum.never
 			? vscode.window.onDidChangeTextEditorSelection(src2docHandler, 500)
 			: undefined;
 

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -21,11 +21,11 @@ let outlineProvider = new Promise<OutlineProvider>(resolve => {
 
 enum ScrollSyncModeEnum {
 	never,
+	onSelectionChangeByMouse,
 	onSelectionChange,
-	onAnyChange,
 }
 
-type ScrollSyncMode = "never" | "onSelectionChange" | "onAnyChange";
+type ScrollSyncMode = "never" | "onSelectionChangeByMouse" | "onSelectionChange";
 
 async function loadHTMLFile(context: vscode.ExtensionContext, relativePath: string) {
 	const filePath = path.resolve(context.extensionPath, relativePath);
@@ -391,7 +391,7 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 				// scroll by mouse
 				(scrollSyncMode !== ScrollSyncModeEnum.never && kind === vscode.TextEditorSelectionChangeKind.Mouse)
 				// scroll by keyboard typing
-				|| (scrollSyncMode === ScrollSyncModeEnum.onAnyChange && kind === vscode.TextEditorSelectionChangeKind.Keyboard));
+				|| (scrollSyncMode === ScrollSyncModeEnum.onSelectionChange && kind === vscode.TextEditorSelectionChangeKind.Keyboard));
 			if (shouldScrollPanel) {
 				console.log(`selection changed, sending src2doc jump request`);
 				reportPosition(doc, editor, 'panelScrollTo');


### PR DESCRIPTION
The description `onSelectionChange` is bad, since it is actually "when selection changes by mouse", but we may keep compability. Regardless of compability, the perfect enums are probably:

```
"onSelectionChange" -> "onSelectionChangeByMouse"
"onAnyChange" -> "onSelectionChange"
```