### PR TITLE
dev: use spawnSync to test exec and add version checking

### DIFF
--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -16,7 +16,7 @@
     "Other"
   ],
   "activationEvents": [],
-  "main": "./out/extension.js",
+  "main": "./out/src/extension.js",
   "contributes": {
     "icons": {
       "typst-guy": {

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -2,10 +2,12 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import { ChildProcessWithoutNullStreams } from 'child_process';
-import { spawn } from 'cross-spawn';
+import { spawn, sync as spawnSync } from 'cross-spawn';
 import { readFile } from 'fs/promises';
 import * as path from 'path';
 import { WebSocket } from 'ws';
+import { version, name } from '../package.json';
+import { error } from 'console';
 
 const vscodeVariables = require('vscode-variables');
 
@@ -80,18 +82,18 @@ export async function getCliPath(extensionPath?: string): Promise<string> {
 	state.bundledPath = bundledPath;
 	state.configPath = configPath;
 
-	const executableExists = (path: string) => {
-		return new Promise(resolve => {
-			try {
-				const spawnRet = spawn(path, ['--help'], {
-					timeout: 1000, /// 1 second
-				});
-				spawnRet.on('error', () => resolve(false));
-				spawnRet.on('exit', (code: number) => resolve(code === 0));
-			} catch {
-				resolve(false);
-			}
-		});
+	const checkExecutable = (path: string): string | null => {
+		const child = spawnSync(path, ['-V'], { timeout: 1000, encoding: 'utf8' });
+		if (child.error) {
+			return child.error.message;
+		}
+		if (child.status !== 0) {
+			return `exit code ${child.status}`;
+		}
+		if (child.stdout.trim() !== `${name} ${version}`) {
+			return `version mismatch, expected ${name} ${version}, got ${child.stdout}`;
+		}
+		return null;
 	};
 
 	const resolvePath = async () => {
@@ -100,15 +102,16 @@ export async function getCliPath(extensionPath?: string): Promise<string> {
 		if (configPath?.length) {
 			return configPath;
 		}
-
-		if (await executableExists(bundledPath)) {
+		const errorMessage = checkExecutable(bundledPath);
+		if (errorMessage === null) {
 			return bundledPath;
 		}
-
 		vscode.window.showWarningMessage(
 			`${state.BINARY_NAME} executable at ${bundledPath} not working,` +
 			`maybe we didn't ship it for your platform or it cannot run due to library issues?` +
-			`In this case you need compile and add ${state.BINARY_NAME} to your PATH.`);
+			`In this case you need compile and add ${state.BINARY_NAME} to your PATH.` +
+			`Error: ${errorMessage}`
+		);
 		return state.BINARY_NAME;
 	};
 

--- a/addons/vscode/tsconfig.json
+++ b/addons/vscode/tsconfig.json
@@ -5,8 +5,9 @@
     "outDir": "out",
     "lib": ["ES2020"],
     "sourceMap": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "skipLibCheck": true,
+    "resolveJsonModule": true,
     "strict": true /* enable all strict type-checking options */
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */


### PR DESCRIPTION
1. use spawnSync to test exec
2. make test result more informative
3. add version checking, ensure extension and binary are of the same version

fix #235 