### PR TITLE
chore: fix typos

### DIFF
--- a/docs/arch.typ
+++ b/docs/arch.typ
@@ -104,7 +104,7 @@ A dedicated thread for the first two actor is necessary because typst use #link(
 
 === Renderer
 
-To achieve incremental and high performance rendering, we use #link("https://github.com/Myriad-Dreamin/typst.ts")[typst.ts] to render docuement. To be specific, we use the `IncrementalSvgExporter`. The `IncrementalSvgExporter` will only output the changed part of the document. The result is serialized to using #link("https://github.com/rkyv/rkyv")[rkyv]. The serialized result is then sent to the client.
+To achieve incremental and high performance rendering, we use #link("https://github.com/Myriad-Dreamin/typst.ts")[typst.ts] to render document. To be specific, we use the `IncrementalSvgExporter`. The `IncrementalSvgExporter` will only output the changed part of the document. The result is serialized to using #link("https://github.com/rkyv/rkyv")[rkyv]. The serialized result is then sent to the client.
 
 == Client Part of Typst Preview
 

--- a/docs/book.typ
+++ b/docs/book.typ
@@ -5,7 +5,7 @@
 
 #book-meta(
   title: "Typst Preview Book",
-  description: "Docuement for typst preview ",
+  description: "Document for typst preview ",
   authors: ("Enter-tainer", "Myriad-Dreamin"),
   language: "en",
   repository: "https://github.com/Enter-tainer/typst-preview",

--- a/docs/intro.typ
+++ b/docs/intro.typ
@@ -83,14 +83,14 @@ Download the `typst-preview` binary for your platform from #link("https://github
 - _`typst watch`_: Using the official typst cli to watch your files and compile them to pdfs. Then open it with your pdf viewer.
 #pros_and_cons(
   [It is supported by the official typst team. Pdf is also the target format of common use cases. This ensures that what you see is what you get.],
-  [It is not responsive. You will have to manually save to docuement to trigger re-compile. It may takes a few seconds to compile and reload the pdf when your document gets big. It also does not support cross jump between code and preview.]
+  [It is not responsive. You will have to manually save to document to trigger re-compile. It may takes a few seconds to compile and reload the pdf when your document gets big. It also does not support cross jump between code and preview.]
 )
 - _#link("https://github.com/nvarner/typst-lsp")[Typst LSP]'s Preview_: Typst LSP will watch your files in memory and compile them to pdfs. It will then open the pdfs in your VSCode. 
 #pros_and_cons(
   [This is quite similar to `typst watch [input]`. But in addition, it can watch changes happening in your VSCode and trigger re-compile. So you can see the preview in real time.],
   [It is not supported by the official typst team. It also does not support cross jump between code and preview.]
 )
-- #link("https://github.com/Enter-tainer/typst-preview")[_Typst Preview_]: We watch changes in your VSCode editor and send changes to the compiler. The compiler use #link("https://github.com/Myriad-Dreamin/typst.ts")[typst.ts] to export the document to an internal incremental IR and send it the preview frontend. The frontend then uses this IR to render the docuement. 
+- #link("https://github.com/Enter-tainer/typst-preview")[_Typst Preview_]: We watch changes in your VSCode editor and send changes to the compiler. The compiler use #link("https://github.com/Myriad-Dreamin/typst.ts")[typst.ts] to export the document to an internal incremental IR and send it the preview frontend. The frontend then uses this IR to render the document. 
 #pros_and_cons(
   [It is super fast and responsive. It supports cross jump between code and preview. It also supports local fonts.],
   [It is not supported by the official typst team. It may also introduce some bugs because it have a different rendering backend from the official typst web app.]


### PR DESCRIPTION
Found via `typos --hidden --format brief`