### PR TITLE
dev: use objcopy to generate split debug symbol

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,12 +123,7 @@ jobs:
         with:
           name: typst-preview-${{ env.target }}.vsix
           path: addons/vscode/typst-preview-${{ env.target }}.vsix
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: typst-preview-${{ env.target }}
-          path: typst-preview-${{ env.target }}${{ fromJSON('["", ".exe"]')[matrix.platform == 'win32'] }}
-      # window: .pdb, linux: .dwp, mac: .dSYM
+      # window: .pdb, linux: .debug, mac: .dSYM
       - name: Upload split debug symbols for windows
         if: matrix.platform == 'win32'
         uses: actions/upload-artifact@v4
@@ -160,6 +155,12 @@ jobs:
           name: typst-preview-${{ env.target }}.dSYM.tar.gz
           path: target/${{ matrix.rust-target }}/release/typst-preview.dSYM.tar.gz
           compression-level: 0
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: typst-preview-${{ env.target }}
+          path: typst-preview-${{ env.target }}${{ fromJSON('["", ".exe"]')[matrix.platform == 'win32'] }}
+  
 
   build_alpine:
     name: build (x86_64-unknown-linux-musl)
@@ -208,15 +209,15 @@ jobs:
         with:
           name: typst-preview-${{ env.target }}.vsix
           path: addons/vscode/typst-preview-${{ env.target }}.vsix
+      - name: Split debug symbols
+        run: |
+          objcopy --compress-debug-sections --only-keep-debug "target/${{ env.RUST_TARGET }}/release/typst-preview" "target/${{ env.RUST_TARGET }}/release/typst-preview.debug"
+          objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "target/${{ env.RUST_TARGET }}/release/typst-preview"
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
           name: typst-preview-${{ env.target }}
           path: typst-preview-${{ env.target }}
-      - name: Split debug symbols
-        run: |
-          objcopy --compress-debug-sections --only-keep-debug "target/${{ env.RUST_TARGET }}/release/typst-preview" "target/${{ env.RUST_TARGET }}/release/typst-preview.debug"
-          objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "target/${{ env.RUST_TARGET }}/release/typst-preview"
       - name: Upload split debug symbols
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,12 +135,18 @@ jobs:
         with:
           name: typst_preview-${{ env.target }}.pdb
           path: target/${{ matrix.rust-target }}/release/typst_preview.pdb
+      - name: Split debug symbols for linux
+        if: matrix.platform == 'linux'
+        run: |
+          objcopy --compress-debug-sections --only-keep-debug "target/${{ matrix.rust-target }}/release/typst-preview" "target/${{ matrix.rust-target }}/release/typst-preview.debug"
+          objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "target/${{ matrix.rust-target }}/release/typst-preview"
       - name: Upload split debug symbols for linux
         if: matrix.platform == 'linux'
         uses: actions/upload-artifact@v4
         with:
-          name: typst-preview-${{ env.target }}.dwp
-          path: target/${{ matrix.rust-target }}/release/typst-preview.dwp
+          name: typst-preview-${{ env.target }}.debug
+          path: target/${{ matrix.rust-target }}/release/typst-preview.debug
+          compression-level: 0
       - name: Package split debug symbols for mac
       # note that debug symbols on mac is a symlink to the actual dSYM directory
         if: matrix.platform == 'darwin'
@@ -168,7 +174,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C target-feature=-crt-static"
     steps:
       - name: Install dependencies
-        run: apk add --no-cache git clang lld musl-dev nodejs npm yarn
+        run: apk add --no-cache git clang lld musl-dev nodejs npm yarn binutils
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -207,11 +213,15 @@ jobs:
         with:
           name: typst-preview-${{ env.target }}
           path: typst-preview-${{ env.target }}
+      - name: Split debug symbols
+        run: |
+          objcopy --compress-debug-sections --only-keep-debug "target/${{ env.RUST_TARGET }}/release/typst-preview" "target/${{ env.RUST_TARGET }}/release/typst-preview.debug"
+          objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "target/${{ env.RUST_TARGET }}/release/typst-preview"
       - name: Upload split debug symbols
         uses: actions/upload-artifact@v4
         with:
-          name: typst-preview-${{ env.target }}.dwp
-          path: target/{{ env.RUST_TARGET }}/release/typst-preview.dwp
+          name: typst-preview-${{ env.target }}.debug
+          path: target/{{ env.RUST_TARGET }}/release/typst-preview.debug
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,6 @@ jobs:
         shell: pwsh
         run: |
           cargo build --release -p typst-preview --target ${{ matrix.rust-target }}
-      # window: .pdb, linux: .debug, mac: .dSYM
       - name: Upload split debug symbols for windows
         if: matrix.platform == 'win32'
         uses: actions/upload-artifact@v4
@@ -137,19 +136,17 @@ jobs:
           name: typst-preview-${{ env.target }}.debug
           path: target/${{ matrix.rust-target }}/release/typst-preview.debug
           compression-level: 0
-      - name: Package split debug symbols for mac
-      # note that debug symbols on mac is a symlink to the actual dSYM directory
+      - name: Split debug symbols for mac
         if: matrix.platform == 'darwin'
         run: |
-          cp -LR "target/${{ matrix.rust-target }}/release/typst-preview.dSYM" "typst-preview.dSYM"
-          tar -czf "target/${{ matrix.rust-target }}/release/typst-preview.dSYM.tar.gz" "typst-preview.dSYM"
+          dsymutil -f "target/${{ matrix.rust-target }}/release/typst-preview"
+          strip -d "target/${{ matrix.rust-target }}/release/typst-preview"
       - name: Upload split debug symbols for mac
         if: matrix.platform == 'darwin'
         uses: actions/upload-artifact@v4
         with:
-          name: typst-preview-${{ env.target }}.dSYM.tar.gz
-          path: target/${{ matrix.rust-target }}/release/typst-preview.dSYM.tar.gz
-          compression-level: 0
+          name: typst-preview-${{ env.target }}.dwarf
+          path: target/${{ matrix.rust-target }}/release/typst-preview.dwarf
       - name: Copy binary to output directory
         shell: pwsh
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,8 +117,6 @@ jobs:
         shell: pwsh
         run: |
           cargo build --release -p typst-preview --target ${{ matrix.rust-target }}
-          cp "target/${{ matrix.rust-target }}/release/typst-preview$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )" "addons/vscode/out/"
-          cp "target/${{ matrix.rust-target }}/release/typst-preview$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )" "typst-preview-${{ env.target }}$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )"
       # window: .pdb, linux: .debug, mac: .dSYM
       - name: Upload split debug symbols for windows
         if: matrix.platform == 'win32'
@@ -131,7 +129,7 @@ jobs:
         run: |
           cd target/${{ matrix.rust-target }}/release
           llvm-objcopy --compress-debug-sections --only-keep-debug "typst-preview" "typst-preview.debug"
-          llvm-objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "typst-preview"
+          llvm-objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" --strip-all "typst-preview"
       - name: Upload split debug symbols for linux
         if: matrix.platform == 'linux'
         uses: actions/upload-artifact@v4
@@ -152,11 +150,15 @@ jobs:
           name: typst-preview-${{ env.target }}.dSYM.tar.gz
           path: target/${{ matrix.rust-target }}/release/typst-preview.dSYM.tar.gz
           compression-level: 0
+      - name: Copy binary to output directory
+        run: |
+          cp "target/${{ matrix.rust-target }}/release/typst-preview$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )" "addons/vscode/out/"
+          cp "target/${{ matrix.rust-target }}/release/typst-preview$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )" "typst-preview-${{ env.target }}$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )"
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
           name: typst-preview-${{ env.target }}
-          path: typst-preview-${{ env.target }}${{ fromJSON('["", ".exe"]')[matrix.platform == 'win32'] }}
+          path: typst-preview-${{ env.target }}$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )
       - name: Package extension
         shell: pwsh
         run: yarn run package -- --target ${{ env.target }} -o typst-preview-${{ env.target }}.vsix
@@ -206,22 +208,24 @@ jobs:
         run: |
           cargo build --release -p typst-preview --target $RUST_TARGET
           mkdir -p addons/vscode/out
-          cp "target/$RUST_TARGET/release/typst-preview" "addons/vscode/out/"
-          cp "target/$RUST_TARGET/release/typst-preview" "typst-preview-alpine-x64"
       - name: Split debug symbols
         run: |
           objcopy --compress-debug-sections --only-keep-debug "target/${{ env.RUST_TARGET }}/release/typst-preview" "target/${{ env.RUST_TARGET }}/release/typst-preview.debug"
           objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "target/${{ env.RUST_TARGET }}/release/typst-preview"
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: typst-preview-${{ env.target }}
-          path: typst-preview-${{ env.target }}
       - name: Upload split debug symbols
         uses: actions/upload-artifact@v4
         with:
           name: typst-preview-${{ env.target }}.debug
           path: target/{{ env.RUST_TARGET }}/release/typst-preview.debug
+      - name: Copy binary to output directory
+        run: |
+          cp "target/${{ env.RUST_TARGET }}/release/typst-preview" "addons/vscode/out/"
+          cp "target/${{ env.RUST_TARGET }}/release/typst-preview" "typst-preview-${{ env.target }}"
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: typst-preview-${{ env.target }}
+          path: typst-preview-${{ env.target }}
       - name: Package extension
         run: yarn run package -- --target ${{ env.target }} -o typst-preview-${{ env.target }}.vsix
         working-directory: ./addons/vscode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.rust-target }}
+      - name: Install llvm
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install llvm
       - name: Install AArch64 target toolchain
         if: matrix.rust-target == 'aarch64-unknown-linux-gnu'
         run: |
@@ -134,8 +139,8 @@ jobs:
         if: matrix.platform == 'linux'
         run: |
           cd target/${{ matrix.rust-target }}/release
-          objcopy --compress-debug-sections --only-keep-debug "typst-preview" "typst-preview.debug"
-          objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "typst-preview"
+          llvm-objcopy --compress-debug-sections --only-keep-debug "typst-preview" "typst-preview.debug"
+          llvm-objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "typst-preview"
       - name: Upload split debug symbols for linux
         if: matrix.platform == 'linux'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: typst-preview-${{ env.target }}.debug
-          path: target/{{ env.RUST_TARGET }}/release/typst-preview.debug
+          path: target/${{ env.RUST_TARGET }}/release/typst-preview.debug
       - name: Copy binary to output directory
         run: |
           cp "target/${{ env.RUST_TARGET }}/release/typst-preview" "addons/vscode/out/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,15 +119,6 @@ jobs:
           cargo build --release -p typst-preview --target ${{ matrix.rust-target }}
           cp "target/${{ matrix.rust-target }}/release/typst-preview$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )" "addons/vscode/out/"
           cp "target/${{ matrix.rust-target }}/release/typst-preview$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )" "typst-preview-${{ env.target }}$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )"
-      - name: Package extension
-        shell: pwsh
-        run: yarn run package -- --target ${{ env.target }} -o typst-preview-${{ env.target }}.vsix
-        working-directory: ./addons/vscode
-      - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: typst-preview-${{ env.target }}.vsix
-          path: addons/vscode/typst-preview-${{ env.target }}.vsix
       # window: .pdb, linux: .debug, mac: .dSYM
       - name: Upload split debug symbols for windows
         if: matrix.platform == 'win32'
@@ -166,6 +157,16 @@ jobs:
         with:
           name: typst-preview-${{ env.target }}
           path: typst-preview-${{ env.target }}${{ fromJSON('["", ".exe"]')[matrix.platform == 'win32'] }}
+      - name: Package extension
+        shell: pwsh
+        run: yarn run package -- --target ${{ env.target }} -o typst-preview-${{ env.target }}.vsix
+        working-directory: ./addons/vscode
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: typst-preview-${{ env.target }}.vsix
+          path: addons/vscode/typst-preview-${{ env.target }}.vsix
+  
   
 
   build_alpine:
@@ -207,14 +208,6 @@ jobs:
           mkdir -p addons/vscode/out
           cp "target/$RUST_TARGET/release/typst-preview" "addons/vscode/out/"
           cp "target/$RUST_TARGET/release/typst-preview" "typst-preview-alpine-x64"
-      - name: Package extension
-        run: yarn run package -- --target ${{ env.target }} -o typst-preview-${{ env.target }}.vsix
-        working-directory: ./addons/vscode
-      - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: typst-preview-${{ env.target }}.vsix
-          path: addons/vscode/typst-preview-${{ env.target }}.vsix
       - name: Split debug symbols
         run: |
           objcopy --compress-debug-sections --only-keep-debug "target/${{ env.RUST_TARGET }}/release/typst-preview" "target/${{ env.RUST_TARGET }}/release/typst-preview.debug"
@@ -229,6 +222,15 @@ jobs:
         with:
           name: typst-preview-${{ env.target }}.debug
           path: target/{{ env.RUST_TARGET }}/release/typst-preview.debug
+      - name: Package extension
+        run: yarn run package -- --target ${{ env.target }} -o typst-preview-${{ env.target }}.vsix
+        working-directory: ./addons/vscode
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: typst-preview-${{ env.target }}.vsix
+          path: addons/vscode/typst-preview-${{ env.target }}.vsix
+  
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,7 @@ jobs:
           path: target/${{ matrix.rust-target }}/release/typst-preview.dSYM.tar.gz
           compression-level: 0
       - name: Copy binary to output directory
+        shell: pwsh
         run: |
           cp "target/${{ matrix.rust-target }}/release/typst-preview$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )" "addons/vscode/out/"
           cp "target/${{ matrix.rust-target }}/release/typst-preview$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )" "typst-preview-${{ env.target }}$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,11 +136,10 @@ jobs:
           name: typst-preview-${{ env.target }}.debug
           path: target/${{ matrix.rust-target }}/release/typst-preview.debug
           compression-level: 0
-      - name: Split debug symbols for mac
+      - name: Collect debug symbols for mac
         if: matrix.platform == 'darwin'
         run: |
           dsymutil -f "target/${{ matrix.rust-target }}/release/typst-preview"
-          strip -d "target/${{ matrix.rust-target }}/release/typst-preview"
       - name: Upload split debug symbols for mac
         if: matrix.platform == 'darwin'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           cd target/${{ matrix.rust-target }}/release
           llvm-objcopy --compress-debug-sections --only-keep-debug "typst-preview" "typst-preview.debug"
-          llvm-objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" --strip-all "typst-preview"
+          llvm-objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "typst-preview"
       - name: Upload split debug symbols for linux
         if: matrix.platform == 'linux'
         uses: actions/upload-artifact@v4
@@ -159,7 +159,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: typst-preview-${{ env.target }}
-          path: typst-preview-${{ env.target }}$(If ('${{ matrix.platform }}' -eq 'win32') { '.exe' } else { '' } )
+          path: typst-preview-${{ env.target }}${{ fromJSON('["", ".exe"]')[matrix.platform == 'win32'] }}
       - name: Package extension
         shell: pwsh
         run: yarn run package -- --target ${{ env.target }} -o typst-preview-${{ env.target }}.vsix
@@ -211,8 +211,9 @@ jobs:
           mkdir -p addons/vscode/out
       - name: Split debug symbols
         run: |
-          objcopy --compress-debug-sections --only-keep-debug "target/${{ env.RUST_TARGET }}/release/typst-preview" "target/${{ env.RUST_TARGET }}/release/typst-preview.debug"
-          objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "target/${{ env.RUST_TARGET }}/release/typst-preview"
+          cd target/$RUST_TARGET/release
+          objcopy --compress-debug-sections --only-keep-debug "typst-preview" "typst-preview.debug"
+          objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "typst-preview"
       - name: Upload split debug symbols
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,8 +133,9 @@ jobs:
       - name: Split debug symbols for linux
         if: matrix.platform == 'linux'
         run: |
-          objcopy --compress-debug-sections --only-keep-debug "target/${{ matrix.rust-target }}/release/typst-preview" "target/${{ matrix.rust-target }}/release/typst-preview.debug"
-          objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "target/${{ matrix.rust-target }}/release/typst-preview"
+          cd target/${{ matrix.rust-target }}/release
+          objcopy --compress-debug-sections --only-keep-debug "typst-preview" "typst-preview.debug"
+          objcopy --strip-debug --add-gnu-debuglink="typst-preview.debug" "typst-preview"
       - name: Upload split debug symbols for linux
         if: matrix.platform == 'linux'
         uses: actions/upload-artifact@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,7 @@ embed-fonts = []
 
 [profile.release]
 debug = true
+# on macos, use split debuginfo
+[target.'cfg(target_os = "macos")'.profile.release]
+debug = true
+split-debuginfo = "packed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,4 +94,3 @@ embed-fonts = []
 
 [profile.release]
 debug = true
-split-debuginfo = "packed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,3 @@ embed-fonts = []
 
 [profile.release]
 debug = true
-# on macos, use split debuginfo
-[target.'cfg(target_os = "macos")'.profile.release]
-debug = true
-split-debuginfo = "packed"


### PR DESCRIPTION
see https://github.com/rust-lang/rust/issues/105991 and https://github.com/rust-lang/rust/issues/34651#issuecomment-1253008705. also https://maskray.me/blog/2022-10-30-distribution-of-debug-information and https://internals.rust-lang.org/t/help-test-faster-incremental-debug-macos-builds-on-nightly/14016