### PR TITLE
fix: show activity bar icon only when current res is typst

### DIFF
--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -121,12 +121,12 @@
           "id": "typst-preview.content-preview",
           "type": "webview",
           "name": "Content",
-          "when": "config.typst-preview.showInActivityBar"
+          "when": "config.typst-preview.showInActivityBar && resourceLangId == typst"
         },
         {
           "id": "typst-preview.outline",
           "name": "Outline",
-          "when": "config.typst-preview.showInActivityBar"
+          "when": "config.typst-preview.showInActivityBar && resourceLangId == typst"
         }
       ]
     },


### PR DESCRIPTION
see https://github.com/microsoft/vscode/issues/49145

fix #287 