### PR TITLE
Add supports for setting sys.inputs

### DIFF
--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -139,6 +139,14 @@
           "default": "",
           "description": "Path to typst-preview executable. If not set, the extension will use bundled typst-preview. If bundled binary is not found, it will use typst-preview installed in PATH"
         },
+        "typst-preview.typstInputs": {
+          "type": "object",
+          "items": {
+            "type": "string"
+          },
+          "default": {},
+          "description": "key-value pairs visible through `sys.inputs`, corresponds to `--input` argument of typst cli"
+        },
         "typst-preview.fontPaths": {
           "type": "array",
           "items": {

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -139,7 +139,7 @@
           "default": "",
           "description": "Path to typst-preview executable. If not set, the extension will use bundled typst-preview. If bundled binary is not found, it will use typst-preview installed in PATH"
         },
-        "typst-preview.typstInputs": {
+        "typst-preview.sysInputs": {
           "type": "object",
           "items": {
             "type": "string"

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -131,7 +131,7 @@ function getCliInputArgs(inputs?: { [key: string]: string }): string[] {
 
 function codeGetCliInputArgs(): string[] {
 	return getCliInputArgs(vscode.workspace.getConfiguration().get<{ [key: string]: string }>(
-		'typst-preview.typstInputs'));
+		'typst-preview.sysInputs'));
 }
 
 export function getCliFontArgs(fontPaths?: string[]): string[] {

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -122,6 +122,18 @@ export async function getCliPath(extensionPath?: string): Promise<string> {
 	return (state.resolved = await resolvePath());
 }
 
+function getCliInputArgs(inputs?: { [key: string]: string }): string[] {
+	return Object.entries(inputs ?? {})
+		.filter(([k, _]) => k.trim() !== "")
+		.map(([k, v]) => ["--input", `${k}=${vscodeVariables(v)}`])
+		.flat();
+}
+
+function codeGetCliInputArgs(): string[] {
+	return getCliInputArgs(vscode.workspace.getConfiguration().get<{ [key: string]: string }>(
+		'typst-preview.typstInputs'));
+}
+
 export function getCliFontArgs(fontPaths?: string[]): string[] {
 	return (fontPaths ?? []).flatMap((fontPath) => ["--font-path", vscodeVariables(fontPath)]);
 }
@@ -533,6 +545,7 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 			...partialRenderingArgs,
 			...invertColorsArgs,
 			...previewInSlideModeArgs,
+			...codeGetCliInputArgs(),
 			...codeGetCliFontArgs(),
 			filePath,
 		], outputChannel, openInBrowser);

--- a/src/args.rs
+++ b/src/args.rs
@@ -87,6 +87,15 @@ pub struct CliArguments {
     #[cfg_attr(feature = "clap", clap(long = "no-open"))]
     pub dont_open_in_browser: bool,
 
+    /// Add a string key-value pair visible through `sys.inputs`
+    #[clap(
+        long = "input",
+        value_name = "key=value",
+        action = clap::ArgAction::Append,
+        value_parser = clap::builder::ValueParser::new(parse_input_pair),
+    )]
+    pub inputs: Vec<(String, String)>,
+
     /// Add additional directories to search for fonts
     #[cfg_attr(
         feature = "clap",
@@ -105,6 +114,23 @@ pub struct CliArguments {
     pub root: Option<PathBuf>,
 
     pub input: PathBuf,
+}
+
+// This parse function comes from typst-cli
+/// Parses key/value pairs split by the first equal sign.
+///
+/// This function will return an error if the argument contains no equals sign
+/// or contains the key (before the equals sign) is empty.
+fn parse_input_pair(raw: &str) -> Result<(String, String), String> {
+    let (key, val) = raw
+        .split_once('=')
+        .ok_or("input must be a key and a value separated by an equal sign")?;
+    let key = key.trim().to_owned();
+    if key.is_empty() {
+        return Err("the key was missing or empty".to_owned());
+    }
+    let val = val.trim().to_owned();
+    Ok((key, val))
 }
 
 pub static LONG_VERSION: Lazy<String> = Lazy::new(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use await_tree::InstrumentAwait;
 use clap::Parser;
 use log::{error, info};
 
+use typst::foundations::{Str, Value};
 use typst_ts_compiler::service::CompileDriver;
 use typst_ts_compiler::TypstSystemWorld;
 use typst_ts_core::config::{compiler::EntryOpts, CompileOpts};
@@ -92,6 +93,9 @@ async fn main() {
     } else {
         std::env::current_dir().unwrap().join(&arguments.input)
     };
+    let inputs = arguments.inputs.iter().map(|(k, v)| {
+        (Str::from(k.as_str()), Value::Str(Str::from(v.as_str())))
+    }).collect();
     let root = if let Some(root) = &arguments.root {
         if root.is_absolute() {
             root.clone()
@@ -109,6 +113,7 @@ async fn main() {
     let compiler_driver = {
         let world = TypstSystemWorld::new(CompileOpts {
             entry: EntryOpts::new_rooted(root.clone(), Some(entry.clone())),
+            inputs,
             font_paths: arguments.font_paths.clone(),
             with_embedded_fonts: typst_assets::fonts().map(Cow::Borrowed).collect(),
             ..CompileOpts::default()


### PR DESCRIPTION
In the cli, the argument is the same as typst cli, which is `--input key=value --input key2=value2 ...`.

However, I'm unsure about how to name the configuration in the VSCode extension. Calling it simply `typst-preview.inputs` seems ambiguous. For now, I'm using `typst-preview.typstInputs`, which can be revised based on further discussion.(Change to `typst-preview.sysInputs`)

I think this could close #213.