### PR TITLE
feat: option to ignore system fonts when previewing

### DIFF
--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -150,7 +150,7 @@
         "typst-preview.systemFonts": {
           "type": "boolean",
           "default": true,
-          "description": "A flag to determine whether to load system fonts."
+          "description": "Whether to load system fonts. If disabled, only fonts in `typst-preview.fontPaths` is loaded"
         },
         "typst-preview.fontPaths": {
           "type": "array",

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -147,6 +147,11 @@
           "default": {},
           "description": "key-value pairs visible through `sys.inputs`, corresponds to `--input` argument of typst cli"
         },
+        "typst-preview.ignoreSystemFonts": {
+          "type": "boolean",
+          "default": false,
+          "description": "Ensures system fonts won't be searched, unless explicitly included via `typst-preview.fontPath`"
+        },
         "typst-preview.fontPaths": {
           "type": "array",
           "items": {

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -147,10 +147,10 @@
           "default": {},
           "description": "key-value pairs visible through `sys.inputs`, corresponds to `--input` argument of typst cli"
         },
-        "typst-preview.ignoreSystemFonts": {
+        "typst-preview.systemFonts": {
           "type": "boolean",
-          "default": false,
-          "description": "Ensures system fonts won't be searched, unless explicitly included via `typst-preview.fontPath`"
+          "default": true,
+          "description": "A flag to determines whether to load system font."
         },
         "typst-preview.fontPaths": {
           "type": "array",

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -150,7 +150,7 @@
         "typst-preview.systemFonts": {
           "type": "boolean",
           "default": true,
-          "description": "A flag to determines whether to load system font."
+          "description": "A flag to determine whether to load system fonts."
         },
         "typst-preview.fontPaths": {
           "type": "array",

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -134,13 +134,19 @@ function codeGetCliInputArgs(): string[] {
 		'typst-preview.sysInputs'));
 }
 
-export function getCliFontArgs(fontPaths?: string[]): string[] {
+export function getCliFontPathArgs(fontPaths?: string[]): string[] {
 	return (fontPaths ?? []).flatMap((fontPath) => ["--font-path", vscodeVariables(fontPath)]);
 }
 
 export function codeGetCliFontArgs(): string[] {
-	return getCliFontArgs(vscode.workspace.getConfiguration().get<string[]>(
+	let ignoreSystemFonts = vscode.workspace.getConfiguration().get<boolean>(
+		'typst-preview.ignoreSystemFonts');
+	let fontPaths = getCliFontPathArgs(vscode.workspace.getConfiguration().get<string[]>(
 		'typst-preview.fontPaths'));
+	return [
+		...(ignoreSystemFonts ? ["--ignore-system-fonts"] : []),
+		...fontPaths
+	];
 }
 
 function getProjectRoot(currentPath: string): string {

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -139,12 +139,12 @@ export function getCliFontPathArgs(fontPaths?: string[]): string[] {
 }
 
 export function codeGetCliFontArgs(): string[] {
-	let ignoreSystemFonts = vscode.workspace.getConfiguration().get<boolean>(
-		'typst-preview.ignoreSystemFonts');
+	let needSystemFonts = vscode.workspace.getConfiguration().get<boolean>(
+		'typst-preview.systemFonts');
 	let fontPaths = getCliFontPathArgs(vscode.workspace.getConfiguration().get<string[]>(
 		'typst-preview.fontPaths'));
 	return [
-		...(ignoreSystemFonts ? ["--ignore-system-fonts"] : []),
+		...(needSystemFonts ? [] : ["--ignore-system-fonts"]),
 		...fontPaths
 	];
 }

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -125,7 +125,7 @@ export async function getCliPath(extensionPath?: string): Promise<string> {
 function getCliInputArgs(inputs?: { [key: string]: string }): string[] {
 	return Object.entries(inputs ?? {})
 		.filter(([k, _]) => k.trim() !== "")
-		.map(([k, v]) => ["--input", `${k}=${vscodeVariables(v)}`])
+		.map(([k, v]) => ["--input", `${k}=${v}`])
 		.flat();
 }
 

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -145,7 +145,7 @@ export function codeGetCliFontArgs(): string[] {
 		'typst-preview.fontPaths'));
 	return [
 		...(needSystemFonts ? [] : ["--ignore-system-fonts"]),
-		...fontPaths
+		...fontPaths,
 	];
 }
 

--- a/addons/vscode/src/test/suite/extension.test.ts
+++ b/addons/vscode/src/test/suite/extension.test.ts
@@ -52,7 +52,13 @@ suite('Extension Test Suite', () => {
     }
   });
 
-  test("FontPaths Configuration Test", async () => {
+  test("Font Configuration Test", async () => {
+
+    /// check default not ignore system fonts
+    jsonIs(assert.strictEqual)(
+      false,
+      vscode.workspace.getConfiguration().get<boolean>("typst-preview.ignoreSystemFonts")
+    );
 
     /// check that default font paths should be []
     jsonIs(assert.strictEqual)(
@@ -61,16 +67,16 @@ suite('Extension Test Suite', () => {
     );
 
     jsonIs(assert.strictEqual)(
-      [], ext.getCliFontArgs(undefined));
+      [], ext.getCliFontPathArgs(undefined));
 
     jsonIs(assert.strictEqual)(
-      [], ext.getCliFontArgs([]));
+      [], ext.getCliFontPathArgs([]));
 
     jsonIs(assert.strictEqual)(
       [], ext.codeGetCliFontArgs());
 
     jsonIs(assert.strictEqual)(
-      ["--font-path", "/path/to/font1", "--font-path", "/path/to/font2"], 
-      ext.getCliFontArgs(["/path/to/font1", "/path/to/font2"]));
+      ["--font-path", "/path/to/font1", "--font-path", "/path/to/font2"],
+      ext.getCliFontPathArgs(["/path/to/font1", "/path/to/font2"]));
   });
 });

--- a/src/args.rs
+++ b/src/args.rs
@@ -96,6 +96,11 @@ pub struct CliArguments {
     )]
     pub inputs: Vec<(String, String)>,
 
+    /// Ensures system fonts won't be searched, unless explicitly included via
+    /// `--font-path`
+    #[arg(long)]
+    pub ignore_system_fonts: bool,
+
     /// Add additional directories to search for fonts
     #[cfg_attr(
         feature = "clap",

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,7 @@ async fn main() {
         let world = TypstSystemWorld::new(CompileOpts {
             entry: EntryOpts::new_rooted(root.clone(), Some(entry.clone())),
             inputs,
+            no_system_fonts: arguments.ignore_system_fonts,
             font_paths: arguments.font_paths.clone(),
             with_embedded_fonts: typst_assets::fonts().map(Cow::Borrowed).collect(),
             ..CompileOpts::default()


### PR DESCRIPTION
Another small option which gives more control over compilation environment.

According to typst/typst#4227, the official designation for this argument has been confirmed as `--ignore-system-fonts`. We follow it in cli argument. In extension, added a `typst-preview.systemFonts` configuration to control it.

Besides, since there is no clear use case for utilizing VSCode variables within sys.input, this PR disables it.