### PR TITLE
Persist webview preview through vscode restarts

### DIFF
--- a/addons/frontend/index.html
+++ b/addons/frontend/index.html
@@ -15,8 +15,10 @@
     <style id="preview-theme-styles"></style>
     <!-- before all of code to avoid rerender by style replacement -->
     <script>
-      // The right side of the equation will be string-replaced later and set in the main.js
-      window.vscode_state = VSCODE_STATE;
+      try {
+        // The right side of the equation will be string-replaced later and set in the main.js
+        window.vscode_state = JSON.parse(`VSCODE_STATE`);
+      } catch (ignored) {}
 
       /// https://stackoverflow.com/questions/13586999/color-difference-similarity-between-two-values-with-js
       function deltaE(rgbA, rgbB) {

--- a/addons/frontend/index.html
+++ b/addons/frontend/index.html
@@ -22,6 +22,7 @@
         state = state.replace("preview-arg:state:", "");
         /// Set it later when acquiring the VSCode API
         window.vscode_state = JSON.parse(state);
+        window.vscode_state.fsPath = atob(window.vscode_state.fsPath);
       }
 
       /// https://stackoverflow.com/questions/13586999/color-difference-similarity-between-two-values-with-js

--- a/addons/frontend/index.html
+++ b/addons/frontend/index.html
@@ -15,6 +15,9 @@
     <style id="preview-theme-styles"></style>
     <!-- before all of code to avoid rerender by style replacement -->
     <script>
+      // The right side of the equation will be string-replaced later and set in the main.js
+      window.vscode_state = VSCODE_STATE;
+
       /// https://stackoverflow.com/questions/13586999/color-difference-similarity-between-two-values-with-js
       function deltaE(rgbA, rgbB) {
         let labA = rgb2lab(rgbA);

--- a/addons/frontend/index.html
+++ b/addons/frontend/index.html
@@ -16,13 +16,21 @@
     <!-- before all of code to avoid rerender by style replacement -->
     <script>
       if (typeof acquireVsCodeApi !== "undefined") {
+        function base64ToString(base64) {
+          const binString = atob(base64);
+          const arr = Uint8Array.from(binString, (m) => m.codePointAt(0));
+          return new TextDecoder().decode(arr);
+        }
         /// The string here is a placeholder 
         /// It will be replaced by the actual preview mode. 
-        let state = `preview-arg:state:{}`;
+        let state = `preview-arg:state:`;
         state = state.replace("preview-arg:state:", "");
-        /// Set it later when acquiring the VSCode API
-        window.vscode_state = JSON.parse(state);
-        window.vscode_state.fsPath = atob(window.vscode_state.fsPath);
+        console.log("state", state);
+        if (state !== "") {
+          /// Set it later when acquiring the VSCode API
+          window.vscode_state = JSON.parse(base64ToString(state));
+          console.log("vscode_state", window.vscode_state);
+        }
       }
 
       /// https://stackoverflow.com/questions/13586999/color-difference-similarity-between-two-values-with-js

--- a/addons/frontend/index.html
+++ b/addons/frontend/index.html
@@ -15,10 +15,14 @@
     <style id="preview-theme-styles"></style>
     <!-- before all of code to avoid rerender by style replacement -->
     <script>
-      try {
-        // The right side of the equation will be string-replaced later and set in the main.js
-        window.vscode_state = JSON.parse(`VSCODE_STATE`);
-      } catch (ignored) {}
+      if (typeof acquireVsCodeApi !== "undefined") {
+        /// The string here is a placeholder 
+        /// It will be replaced by the actual preview mode. 
+        let state = `preview-arg:state:{}`;
+        state = state.replace("preview-arg:state:", "");
+        /// Set it later when acquiring the VSCode API
+        window.vscode_state = JSON.parse(state);
+      }
 
       /// https://stackoverflow.com/questions/13586999/color-difference-similarity-between-two-values-with-js
       function deltaE(rgbA, rgbB) {

--- a/addons/frontend/src/main.js
+++ b/addons/frontend/src/main.js
@@ -92,6 +92,10 @@ function setupVscodeChannel(nextWs) {
     if (vscodeAPI?.postMessage) {
         vscodeAPI.postMessage({ type: 'started' });
     }
+    if (vscodeAPI?.setState && window.vscode_state) {
+        vscodeAPI.setState(window.vscode_state);
+    }
+
 
     // Handle messages sent from the extension to the webview
     window.addEventListener('message', event => {

--- a/addons/vscode/package.json
+++ b/addons/vscode/package.json
@@ -16,7 +16,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onWebviewPanel:typst-preview"
+  ],
   "main": "./out/src/extension.js",
   "contributes": {
     "icons": {

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -495,7 +495,9 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 		html = html.replace(
 			"preview-arg:previewMode:Doc",
 			`preview-arg:previewMode:${previewMode}`
-		).replace("preview-arg:state:{}", `preview-arg:state:${JSON.stringify({ mode: task.mode, fsPath: bindDocument.uri.fsPath.replace(/`/g, "").replace(/"/g, "") })}`);
+		).replace("preview-arg:state:{}", `preview-arg:state:${JSON.stringify({ mode: task.mode, fsPath: bindDocument.uri.fsPath.replace(/`/g, "\\`") })}`);
+		// Replace all the backticks here ^ to avoid the backtick "escaping" the string in the JS itself and executing other code.
+
 		panel.webview.html = html.replace("ws://127.0.0.1:23625", `ws://127.0.0.1:${dataPlanePort}`);
 		// 虽然配置的是 http，但是如果是桌面客户端，任何 tcp 连接都支持，这也就包括了 ws
 		// https://code.visualstudio.com/api/advanced-topics/remote-extensions#forwarding-localhost

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -495,8 +495,7 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 		html = html.replace(
 			"preview-arg:previewMode:Doc",
 			`preview-arg:previewMode:${previewMode}`
-		).replace("preview-arg:state:{}", `preview-arg:state:${JSON.stringify({ mode: task.mode, fsPath: bindDocument.uri.fsPath.replace(/`/g, "\\`") })}`);
-		// Replace all the backticks here ^ to avoid the backtick "escaping" the string in the JS itself and executing other code.
+		).replace("preview-arg:state:{}", `preview-arg:state:${JSON.stringify({ mode: task.mode, fsPath: Buffer.from(bindDocument.uri.fsPath).toString("base64") })}`);
 
 		panel.webview.html = html.replace("ws://127.0.0.1:23625", `ws://127.0.0.1:${dataPlanePort}`);
 		// 虽然配置的是 http，但是如果是桌面客户端，任何 tcp 连接都支持，这也就包括了 ws

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -492,10 +492,12 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 				.toString()}/typst-webview-assets`
 		);
 		const previewMode = task.mode === 'doc' ? "Doc" : "Slide";
+		const previewState = { mode: task.mode, fsPath: bindDocument.uri.fsPath };
+		const previewStateEncoded = Buffer.from(JSON.stringify(previewState), 'utf-8').toString('base64');
 		html = html.replace(
 			"preview-arg:previewMode:Doc",
 			`preview-arg:previewMode:${previewMode}`
-		).replace("preview-arg:state:{}", `preview-arg:state:${JSON.stringify({ mode: task.mode, fsPath: Buffer.from(bindDocument.uri.fsPath).toString("base64") })}`);
+		).replace("preview-arg:state:", `preview-arg:state:${previewStateEncoded}`);
 
 		panel.webview.html = html.replace("ws://127.0.0.1:23625", `ws://127.0.0.1:${dataPlanePort}`);
 		// 虽然配置的是 http，但是如果是桌面客户端，任何 tcp 连接都支持，这也就包括了 ws

--- a/addons/vscode/src/extension.ts
+++ b/addons/vscode/src/extension.ts
@@ -495,7 +495,7 @@ const launchPreview = async (task: LaunchInBrowserTask | LaunchInWebViewTask) =>
 		html = html.replace(
 			"preview-arg:previewMode:Doc",
 			`preview-arg:previewMode:${previewMode}`
-		).replace("VSCODE_STATE", JSON.stringify({ mode: task.mode, fsPath: bindDocument.uri.fsPath }));
+		).replace("preview-arg:state:{}", `preview-arg:state:${JSON.stringify({ mode: task.mode, fsPath: bindDocument.uri.fsPath.replace(/`/g, "").replace(/"/g, "") })}`);
 		panel.webview.html = html.replace("ws://127.0.0.1:23625", `ws://127.0.0.1:${dataPlanePort}`);
 		// 虽然配置的是 http，但是如果是桌面客户端，任何 tcp 连接都支持，这也就包括了 ws
 		// https://code.visualstudio.com/api/advanced-topics/remote-extensions#forwarding-localhost


### PR DESCRIPTION
Hello!

This is a small PR implementing the [serialization](https://code.visualstudio.com/api/extension-guides/webview#serialization) feature which lets the webviews persist over VSCode restarts :)

To see its effect, try opening up a Typst Preview inside VSCode, then run the "Developer: Reload Window" command or close and open VSCode. Before this PR, the Typst Preview would cease to exist. After it, it should re-load.